### PR TITLE
F/expand collapse

### DIFF
--- a/src/js/components/accordion/accordion-item.js
+++ b/src/js/components/accordion/accordion-item.js
@@ -45,7 +45,6 @@ export default React.createClass({
 
   headerClasses() {
     var classes = [
-      'accordion-item-head',
       'pointer',
       'flex',
       'flex-center',
@@ -57,9 +56,7 @@ export default React.createClass({
   },
 
   contentClasses() {
-    var classes = [
-      'accordion-item-content'
-    ]
+    var classes = [];
     this.state.isOpen ? classes.push('is_open') : classes.push('is_closed', 'overflow-hidden');
     return classes.join(' ');
   },

--- a/src/js/components/accordion/accordion-item.js
+++ b/src/js/components/accordion/accordion-item.js
@@ -60,7 +60,7 @@ export default React.createClass({
     var classes = [
       'accordion-item-content'
     ]
-    this.state.isOpen ? classes.push('open') : classes.push('close overflow-hidden');
+    this.state.isOpen ? classes.push('open') : classes.push('close', 'overflow-hidden');
     return classes.join(' ');
   },
 

--- a/src/js/components/accordion/accordion-item.js
+++ b/src/js/components/accordion/accordion-item.js
@@ -60,7 +60,7 @@ export default React.createClass({
     var classes = [
       'accordion-item-content'
     ]
-    this.state.isOpen ? classes.push('open') : classes.push('close');
+    this.state.isOpen ? classes.push('open') : classes.push('close overflow-hidden');
     return classes.join(' ');
   },
 

--- a/src/js/components/accordion/accordion-item.js
+++ b/src/js/components/accordion/accordion-item.js
@@ -7,7 +7,9 @@ export default React.createClass({
   displayName: "AccordionItem",
 
   propTypes: {
-    isOpen: Type.bool
+    isOpen: Type.bool,
+    title: Type.node.isRequired,
+    isLast: Type.bool
   },
 
   getDefaultProps() {

--- a/src/js/components/accordion/accordion-item.js
+++ b/src/js/components/accordion/accordion-item.js
@@ -1,0 +1,93 @@
+import React from 'react';
+
+const Type = React.PropTypes;
+
+export default React.createClass({
+
+  displayName: "AccordionItem",
+
+  propTypes: {
+    isOpen: Type.bool
+  },
+
+  getDefaultProps() {
+    return {
+      isOpen: false
+    };
+  },
+
+  getInitialState() {
+    return {
+      isOpen: this.props.isOpen
+    }
+  },
+
+  // this sets the state when the expand all / collapse all in the parent passes isOpen prop
+  componentWillReceiveProps(nextProps) {
+    this.setState({isOpen: nextProps.isOpen})
+  },
+
+  handleClick(){
+    this.setState({
+      isOpen: !this.state.isOpen
+    })
+  },
+
+  iconClasses() {
+    var classes = [
+      'mr1'
+    ];
+    this.state.isOpen ? classes.push('icon-collapse','blue') : classes.push('icon-expand','blue');
+    return classes.join(' ');
+  },
+
+  headerClasses() {
+    var classes = [
+      'accordion-item-head',
+      'pointer',
+      'flex',
+      'flex-center',
+      'py2'
+    ];
+
+    return classes.join(' ');
+
+  },
+
+  contentClasses() {
+    var classes = [
+      'accordion-item-content'
+    ]
+    this.state.isOpen ? classes.push('open') : classes.push('close');
+    return classes.join(' ');
+  },
+
+  containerClasses() {
+    var classes = [
+      'bt',
+      'bw-1',
+      'bc-blue-baby',
+      'px2'
+    ];
+
+    if(this.props.isLast) {
+      classes.push('bb');
+    }
+
+    return classes.join(' ');
+
+  },
+
+  render() {
+    return (
+      <div className={this.containerClasses()}>
+        <div className={this.headerClasses()} onClick={this.handleClick}>
+          <span className={this.iconClasses()}/>
+          {this.props.title}
+        </div>
+        <div className={this.contentClasses()}>{this.props.children}</div>
+      </div>
+    );
+  }
+
+});

--- a/src/js/components/accordion/accordion-item.js
+++ b/src/js/components/accordion/accordion-item.js
@@ -60,7 +60,7 @@ export default React.createClass({
     var classes = [
       'accordion-item-content'
     ]
-    this.state.isOpen ? classes.push('open') : classes.push('close', 'overflow-hidden');
+    this.state.isOpen ? classes.push('is_open') : classes.push('is_closed', 'overflow-hidden');
     return classes.join(' ');
   },
 

--- a/src/js/nav-container.js
+++ b/src/js/nav-container.js
@@ -58,6 +58,7 @@ export default React.createClass({
             <li className="nav-item py2 px3"><a className="nav-link" href="/modals">Modals</a></li>
             <li className="nav-item py2 px3"><a className="nav-link" href="/cards">Cards</a></li>
             <li className="nav-item py2 px3"><a className="nav-link" href="/animations">Animations</a></li>
+            <li className="nav-item py2 px3"><a className="nav-link" href="/accordions">Accordions</a></li>
           </ul>
         </nav>
         <section className="content-container flex-auto tall">{this.props.children}</section>

--- a/src/js/nav-container.js
+++ b/src/js/nav-container.js
@@ -69,7 +69,8 @@ export default React.createClass({
           D.li({className: "nav-item py2 px3"}, D.a({ className: "nav-link", href: '/popovers' }, 'Popovers')),
           D.li({className: "nav-item py2 px3"}, D.a({ className: "nav-link", href: '/modals' }, 'Modals')),
           D.li({className: "nav-item py2 px3"}, D.a({ className: "nav-link", href: '/cards' }, 'Cards')),
-          D.li({className: "nav-item py2 px3"}, D.a({ className: "nav-link", href: '/animations' }, 'Animations'))
+          D.li({className: "nav-item py2 px3"}, D.a({ className: "nav-link", href: '/animations' }, 'Animations')),
+          D.li({className: "nav-item py2 px3"}, D.a({ className: "nav-link", href: '/accordions' }, 'Accordions'))
         ])
       ]),
       D.section({

--- a/src/js/pages/accordions.js
+++ b/src/js/pages/accordions.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import Styleguide from '../styleguide';
+import PropsTable from '../style_guide_components/props-table';
+import AccordionItem from '../components/accordion/accordion-item';
+
+export default React.createClass({
+
+  displayName: "AccordionsPage",
+
+  getInitialState() {
+    return {
+      accordionOpen: false
+    }
+  },
+
+  renderToggleAccordion() {
+
+    var iconClasses = [
+      'mr1'
+    ];
+
+    this.state.accordionOpen ? iconClasses.push('icon-collapse') : iconClasses.push('icon-expand');
+
+    return <a onClick={this.toggleAccordion} className="flex flex-center mb1 blue pointer">
+        <span className={iconClasses.join(' ')} />
+        <span>{this.state.accordionOpen ? "Collapse all" : "Expand all" }</span>
+      </a>
+  },
+
+  toggleAccordion() {
+    this.setState({accordionOpen: !this.state.accordionOpen});
+  },
+
+  render() {
+    return <Styleguide title="Accordions">
+      <div title="Accordions" description="The accordion styles for Namely">
+        <PropsTable rows={
+          [
+            {
+              'prop':'isOpen',
+              'description':'Opens and closes the item with height and overflow css. Default: false'
+            },
+            {
+              'prop': 'title',
+              'description': 'The node or string that will be used to toggle the item.  Required.'
+            },
+            {
+              'prop': 'isLast',
+              'description': 'Set this to true on the last item to give it a bottom border.'
+            }
+          ]
+        }/>
+        <hr />
+
+        { this.renderToggleAccordion() }
+        <AccordionItem
+          title={<h3 className="mb0 blue">{"Accordion Item 1"}</h3>}
+          isOpen={this.state.accordionOpen}>
+          <p>{"Lorem ipsum dolor sit amet, consectetur adipiscing elit. In laoreet ipsum sapien, vitae posuere sapien consectetur sed. Suspendisse non lorem quis quam mollis vestibulum blandit sit amet lectus. Quisque sagittis sapien enim, quis maximus mauris fermentum non."}</p>
+        </AccordionItem>
+
+        <AccordionItem
+          title={<h3 className="mb0 blue">{"Accordion Item 2"}</h3>}
+          isOpen={this.state.accordionOpen}>
+          <p>{"Morbi elit dui, pellentesque a malesuada et, lobortis sit amet nisl. Integer purus lorem, sodales aliquam facilisis non, iaculis id nisl. Nam fringilla elementum turpis, a venenatis risus luctus ac. Ut rhoncus viverra mi, ut sodales nibh sollicitudin ut. Ut ut elit sit amet magna semper blandit. "}</p>
+        </AccordionItem>
+
+      </div>
+    </Styleguide>
+  }
+});
+
+

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -13,6 +13,7 @@ import ModalsPage from './pages/modals';
 import CardsPage from './pages/cards';
 import IconsPage from './pages/icons';
 import AnimationsPage from './pages/animations';
+import AccordionsPage from './pages/accordions';
 
 let appContainer = document.getElementById('app');
 
@@ -36,6 +37,7 @@ export default Router.extend({
     'cards': 'cards',
     'icons': 'icons',
     'animations': 'animations',
+    'accordions': 'accordions'
   },
 
   home() {
@@ -84,6 +86,10 @@ export default Router.extend({
 
   animations() {
     this.renderPage(AnimationsPage);
+  },
+  accordions() {
+    this.renderPage(AccordionsPage);
   }
+
 
 });

--- a/src/scss/base/_states.scss
+++ b/src/scss/base/_states.scss
@@ -30,3 +30,11 @@
 .pointer {
   cursor: pointer;
 }
+
+.is_open {
+  height: auto;
+}
+
+.is_closed {
+  height: 0;
+}

--- a/src/scss/components/_accordions.scss
+++ b/src/scss/components/_accordions.scss
@@ -1,8 +1,1 @@
-.accordion-item-content {
-  &.close {
-    height: 0;
-  }
-  &.open {
-    height: auto;
-  }
-}
+// now using util classes in component. keeping this file around just in case...

--- a/src/scss/components/_accordions.scss
+++ b/src/scss/components/_accordions.scss
@@ -1,7 +1,6 @@
 .accordion-item-content {
   &.close {
     height: 0;
-    overflow: hidden;
   }
   &.open {
     height: auto;

--- a/src/scss/components/_accordions.scss
+++ b/src/scss/components/_accordions.scss
@@ -1,0 +1,9 @@
+.accordion-item-content {
+  &.close {
+    height: 0;
+    overflow: hidden;
+  }
+  &.open {
+    height: auto;
+  }
+}

--- a/src/scss/components/_components.scss
+++ b/src/scss/components/_components.scss
@@ -14,3 +14,5 @@
 @import 'triangle';
 
 @import 'modal';
+
+@import 'accordions';


### PR DESCRIPTION
![out](https://cloud.githubusercontent.com/assets/173215/9334943/6bf81092-459f-11e5-9451-3f62f56302e5.gif)

### On the parent component:

optionally set the state of the items, so that they can all be open or all be closed:


    getInitialState() {
      return {
        accordionOpen: false
      }
    },

set up a button that will toggle that state:

    renderToggleAccordion() {
      var iconClasses = ['mr1'];
      this.state.accordionOpen ? iconClasses.push('icon-collapse') : iconClasses.push('icon-expand');
      return <a onClick={this.toggleAccordion} className="flex flex-center mb1 blue pointer">
          <span className={iconClasses.join(' ')} />
          <span>{this.state.accordionOpen ? "Collapse all" : "Expand all" }</span>
        </a>
    },

the button's click handler:

    toggleAccordion() {
      this.setState({accordionOpen: !this.state.accordionOpen});
    },


render the accordion items inside the parent's `render()`.  The `AccordionItem` component most likely render inside some kind of `children.map` function, but listing them out explicitly here:

    { this.renderToggleAccordion() }

    <AccordionItem
      title={<h3 className="mb0 blue">{"Accordion Item 1"}</h3>}
      isOpen={this.state.accordionOpen}>
      <p>{"Lorem ipsum dolor sit amet, consectetur adipiscing elit.
      In laoreet ipsum sapien, vitae posuere sapien consectetur sed.
      Suspendisse non lorem quis quam mollis vestibulum blandit sit
      amet lectus. Quisque sagittis sapien enim, quis maximus mauris
      fermentum non."}</p>
    </AccordionItem>

    <AccordionItem
      title={<h3 className="mb0 blue">{"Accordion Item 2"}</h3>}
      isOpen={this.state.accordionOpen}>
      <p>{"Morbi elit dui, pellentesque a malesuada et, lobortis sit
      amet nisl. Integer purus lorem, sodales aliquam facilisis non,
      iaculis id nisl. Nam fringilla elementum turpis, a venenatis
      risus luctus ac. Ut rhoncus viverra mi, ut sodales nibh sollicitudin
      ut. Ut ut elit sit amet magna semper blandit. "}</p>
    </AccordionItem>
