### PR TITLE
fix(caps utility): remove massive letter-spacing from .caps class

### DIFF
--- a/src/scss/elements/_typography.scss
+++ b/src/scss/elements/_typography.scss
@@ -52,7 +52,7 @@ h6, .h6 { font-size: $h6; }
 .bold    { font-weight: bold; }
 .regular { font-weight: normal; }
 .italic  { font-style: italic; }
-.caps    { letter-spacing: 0.2em; text-transform: uppercase; }
+.caps    { text-transform: uppercase; }
 
 .left-align   { text-align: left; }
 .center       { text-align: center; }


### PR DESCRIPTION
The current letterspacing for `caps` is quite wide:

![screen shot 2015-07-02 at 4 14 31 pm](https://cloud.githubusercontent.com/assets/3051193/8486801/79ef1b76-20d5-11e5-9556-ab42fb7cd74e.png)

I removed that letterspacing to make it look correct:
![screen shot 2015-07-02 at 4 16 20 pm](https://cloud.githubusercontent.com/assets/3051193/8486829/bdd6ba2e-20d5-11e5-808d-b9421d1127d4.png)

