### PR TITLE
fix(styles): no more scss-lint errors

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -86,6 +86,7 @@ linters:
       line-height: []
       margin: ['rem', 'px']
       transition: ['s']
+      animation-duration: ['s']
 
   QualifyingElement:
     enabled: true
@@ -94,6 +95,8 @@ linters:
     enabled: true
 
   SelectorFormat:
+    exclude:
+      - './src/scss/elements/_select.scss'
     enabled: true
 
   SingleLinePerProperty:

--- a/src/scss/animations/_easing.scss
+++ b/src/scss/animations/_easing.scss
@@ -1,4 +1,4 @@
-.linear { -webkit-animation-timing-function: linear; animation-timing-function: linear }
-.ease-in { -webkit-animation-timing-function: ease-in; animation-timing-function: ease-in }
-.ease-out { -webkit-animation-timing-function: ease-out; animation-timing-function: ease-out }
-.ease-in-out { -webkit-animation-timing-function: ease-in-out; animation-timing-function: ease-in-out }
+.linear { animation-timing-function: linear; }
+.ease-in { animation-timing-function: ease-in; }
+.ease-out { animation-timing-function: ease-out; }
+.ease-in-out { animation-timing-function: ease-in-out; }

--- a/src/scss/animations/_fade.scss
+++ b/src/scss/animations/_fade.scss
@@ -1,11 +1,11 @@
 .anim-fade {
-  opacity: 0;
-  animation-name: fade;
   animation-duration: 0.35s;
   animation-fill-mode: forwards;
+  animation-name: fade;
+  opacity: 0;
 }
 
 @keyframes fade {
-    0% { opacity: 0 }
-  100% { opacity: 1 }
+  0% { opacity: 0; }
+  100% { opacity: 1; }
 }

--- a/src/scss/animations/_zoom.scss
+++ b/src/scss/animations/_zoom.scss
@@ -1,11 +1,11 @@
 .zoom {
-  transform: scale(0);
-  animation-name: zoom;
   animation-duration: 0.2s;
   animation-fill-mode: forwards;
+  animation-name: zoom;
+  transform: scale(0);
 }
 
 @keyframes zoom {
-    0% { transform: scale(0) }
-  100% { transform: scale(1) }
+  0% { transform: scale(0); }
+  100% { transform: scale(1); }
 }


### PR DESCRIPTION
Finally took some time fix some pestering scss-lint warnings. scss-lint currently ignores the `_select.scss` partial for SelectorFormat until we fork and fix the third-party component or replace it with something else. 