### PR TITLE
[RFC] styleguide.js

### DIFF
--- a/src/js/styleguide.js
+++ b/src/js/styleguide.js
@@ -1,22 +1,27 @@
 import React from 'react';
 
-export default React.createClass({
-  displayName: "Styleguide",
+const {
+  Component,
+} = React;
 
-  listComponentTitles: function () {
+class Styleguide extends Component {
+
+  listComponentTitles() {
     let children = this.props.children;
 
     children = (React.Children.count(children) == 1) ? [children] : children;
 
     return React.Children.map(children, function (child) {
       let title = child.props.title.replace(" ", "-");
-      return React.createElement("li", {className: "py1 blue"}, React.createElement("a", {
-        href: `#${title}`
-      }, child.props.title));
+      return (
+        <li className={"py1 blue"}>
+          <a href={"#"+title}>{child.props.title}</a>
+        </li>
+      );
     });
-  },
+  }
 
-  listComponents: function () {
+  listComponents() {
     let children = this.props.children;
     let self = this;
 
@@ -24,39 +29,48 @@ export default React.createClass({
     return React.Children.map(children, function (child) {
       let title = child.props.title.replace(" ", "-");
 
-      return React.createElement("div", {
-        className: "styleguide-components-component py3",
-        id: title
-      }, React.createElement("h2", {
-        className: "styleguide-components-component-title"
-      }, child.props.title), React.createElement("p", {
-        className: "styleguide-components-component-description"
-      }, child.props.description), React.createElement("div", {
-        className: "styleguide-components-component-example"
-      }, child.props.children), self.props.example ? React.createElement("div", {
-        className: "styleguide-components-component-code"
-      }, React.createElement("pre", null, React.createElement("code", {
-        className: self.props.codeClassName ? self.props.codeClassName : "language-javascript"
-      }, self.props.highlight ? self.props.highlight(child.props.example) : child.props.example))) : void 0
+      return (
+        <div className="styleguide-components-component py3" id={title}>
+          <h2 className="styleguide-components-component-title">{child.props.title}</h2>
+          <p className="styleguide-components-component-description">{child.props.description}</p>
+          <div className="styleguide-components-component-example">{child.props.children}</div>
+          {self.example(child)}
+        </div>
       );
     });
-  },
-
-  render: function () {
-    return (React.createElement("div", {
-      className: "styleguide flex tall"
-    }, React.createElement("div", {
-      className: "styleguide-sidebar col-2 py5 px3 br bw-1 bc-grey-15"
-    }, [
-      React.createElement("h5", {
-        className: "styleguide-sidebar-title grey-15 py2"
-      }, this.props.title),
-      React.createElement("ul", {
-        className: "styleguide-sidebar-list list-reset"
-      }, this.listComponentTitles())
-    ]), React.createElement("div", {
-      className: "styleguide-components flex-auto overflow-scroll p4"
-    }, this.listComponents())));
   }
-});
 
+  example(child) {
+    if (this.props.example) {
+      return (
+        <div className="styleguide-components-component-code">
+          <pre>
+            <code className={this.props.codeClassName ? this.props.codeClassName : "language-javascript"}>
+              {this.props.highlight ? this.props.highlight(child.props.example) : child.props.example}
+            </code>
+          </pre>
+        </div>
+      );
+    } else {
+      void 0;
+    }
+  }
+
+  render() {
+
+    return (
+      <div className="styleguide flex tall">
+        <div className="styleguide-sidebar col-2 py5 px3 br bw-1 bc-grey-15">
+          <h5 className="styleguide-sidebar-title grey-15 py2">{this.props.title}</h5>
+          <ul className="styleguide-sidebar-list list-reset">{this.listComponentTitles()}</ul>
+        </div>
+        <div className="styleguide-components flex-auto overflow-scroll p4">{this.listComponents()}</div>
+      </div>
+    );
+  }
+
+}
+
+Styleguide.displayName = "Styleguide";
+
+export default Styleguide;


### PR DESCRIPTION
In moving over some of the parts to make the View Component part of the Styleguide, I realized it might require some minor refactoring of the base level stuff displaying the actual Styleguide. These types of refactors bringing the codebase up to date with modern React and ES6 conventions can probably be done in small PRs and iteratively. So here's the first refactor.