### PR TITLE
another huge one

### DIFF
--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -155,6 +155,7 @@ label {
 
   &:checked:before {
     background: $grey-50;
+    border: 0;
     border-radius: 5px;
     content: '';
     cursor: pointer;


### PR DESCRIPTION
The current radio button in Namely has a `:checked:before` border width.  This resets to 0, fixing my googly-eyes radio buttons in the PTO build.