### PR TITLE
[RFC] Adds Fetch To Stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "alt": "^0.17.1",
     "core-js": "^0.9.6",
+    "node-fetch": "^1.3.2",
     "react": "^0.12.1",
     "react-select": "^0.4.9"
   },


### PR DESCRIPTION
Adds node-fetch as a dependency for calls to an API.

Allows for use of fetcher conventions for allowing actions / stores to interact with an API as seen here:
https://reactjsnews.com/getting-started-with-flux/