### PR TITLE
[RFC] Creates Simple Fetcher Wrapper for API Calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "alt": "^0.17.1",
     "core-js": "^0.9.6",
+    "node-fetch": "^1.3.2",
     "react": "^0.12.1",
     "react-select": "^0.4.9"
   },

--- a/src/js/fetcher.js
+++ b/src/js/fetcher.js
@@ -1,0 +1,12 @@
+import 'node-fetch'
+
+export default (url, callback) => {
+  fetch(url)
+    .then( (res) => {
+      let resJson = res.json();
+      return resJson;
+    })
+    .then( (json) => {
+      callback(json);
+    });
+}


### PR DESCRIPTION
Depends on: https://github.com/namely/styleguide/pull/70

Allows components / actions / stores to make api requests using a fetcher.

example: ```fetcher("http://echo.jsontest.com/key/value/one/two", this.getResponse)```

Once the fetcher is imported, it takes a *full* URL and a callback as parameters.