### PR TITLE
hover-row utility

### DIFF
--- a/src/scss/base/_states.scss
+++ b/src/scss/base/_states.scss
@@ -23,6 +23,10 @@
   color: $orange;
 }
 
+.hover-row:hover {
+  background: $grey-5;
+}
+
 .pointer {
   cursor: pointer;
 }

--- a/src/scss/base/_tables.scss
+++ b/src/scss/base/_tables.scss
@@ -50,8 +50,3 @@ tbody tr:last-child td {
   border-bottom: 0;
 }
 
-.table-hover {
-  tbody tr:hover {
-    background: $grey-5;
-  }
-}

--- a/src/scss/base/_tables.scss
+++ b/src/scss/base/_tables.scss
@@ -50,6 +50,8 @@ tbody tr:last-child td {
   border-bottom: 0;
 }
 
-tbody tr:hover {
-  background: $grey-5;
+.table-hover {
+  tbody tr:hover {
+    background: $grey-5;
+  }
 }


### PR DESCRIPTION
Based off of @tsargent's PR #78, `.hover-row` is more general utility for adding this type of interactive state to any "row" of data, as it is a common pattern around the Namely app. i.e. 

![](https://aha-attachments-prod.s3.amazonaws.com/attachments/816fa8d7972f7688b576c189561595d2f636f27d/original.png?1438261952)

I wanted to make edits to Tyler's PR but I didn't have the push permissions. :shrug: