### PR TITLE
[RFC] Adds Complete /dist Path to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ public/app.css
 public/app.css.map
 public/prism-twilight.css
 public/fonts/
-dist/namely-ui.css
+dist/


### PR DESCRIPTION
Up for discussion pending an audit of our deployment and integration. Built out files from ```gulp``` should be bundled from ```/src``` and built on install (or ```preinstall```) without having to commit a bunch of files for small changes.