### PR TITLE
adds button-baby as button-link option

### DIFF
--- a/src/js/components/buttons/button.js
+++ b/src/js/components/buttons/button.js
@@ -6,7 +6,7 @@ export default React.createClass({
   displayName: "Button",
 
   propTypes: {
-   type: Type.oneOf([null, 'danger', 'secondary', 'previous', 'next']),
+   type: Type.oneOf([null, 'danger', 'secondary', 'baby', 'previous', 'next']),
    label: Type.string,
    size: Type.oneOf([null, 'sm']),
    disabled: Type.bool,

--- a/src/js/pages/buttons.js
+++ b/src/js/pages/buttons.js
@@ -34,6 +34,7 @@ export default React.createClass({
       <div title="Links">
         <Button label=".button-link" link={ true } extraClasses={ ["mr3"] } />
         <Button label=".button-link.button-secondary" type="secondary" link={ true } extraClasses={ ["mr3"] } />
+        <Button label=".button-link.button-baby" type="baby" link={ true } extraClasses={ ["mr3"] } />
         <Button label=".button-link.button-danger" type="danger" link={ true } extraClasses={ ["mr3"] } />
         <Button label=".button-link:disabled" link={ true } disabled={ true } extraClasses={ ["mr3"] } />
         <Button label=".button-link.button-sm" size="sm" link={ true } extraClasses={ ["mr3"] } />

--- a/src/scss/elements/buttons/_types.scss
+++ b/src/scss/elements/buttons/_types.scss
@@ -11,6 +11,18 @@
   }
 }
 
+.button-baby {
+  background: $blue-baby;
+
+  &:hover {
+    background: $blue;
+  }
+
+  &:active {
+    background: $blue-tertiary;
+  }
+}
+
 // Danger Button
 .button-danger {
   background: $orange;
@@ -58,6 +70,18 @@
 
     &:active {
       color: $orange-dark;
+    }
+  }
+
+  &.button-baby {
+    color: $blue-baby;
+
+    &:hover {
+      color: $blue;
+    }
+
+    &:active {
+      color: $blue-tertiary;
     }
   }
 


### PR DESCRIPTION
This is an addition to the group of `button-link` type Buttons for the styleguide. It is needed for this feature: 

![](https://aha-attachments-prod.s3.amazonaws.com/attachments/816fa8d7972f7688b576c189561595d2f636f27d/original.png?1438261952)

## Preview:
http://quick.as/xnYCZgrd