### PR TITLE
allows gulp connect to run on other ports

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -97,6 +97,7 @@ gulp.task('colors', function(){
 gulp.task('server', ['icons', 'colors', 'import-styles', 'styles', 'scripts'], function(){
   connect.server({
     root: ['public'],
+    port: gutil.env.port || 8080,
     livereload: true,
     middleware: function() {
       return [

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ $ gem install scss-lint
 ```shell
 $ npm start
 ```
+To serve on a port other than 8080:
+```shell
+$ gulp --port 8081
+```
 
 
 Packaging Files for Production


### PR DESCRIPTION
This allows us to serve the styleguide locally on a port other than 8080:
```
$ gulp --port 8081
```

If `--port ` isn't set, defaults to 8080.

Useful for serving Namely and the stylguide at the same time.