### PR TITLE
add utility class for user-select: none

### DIFF
--- a/src/scss/elements/_typography.scss
+++ b/src/scss/elements/_typography.scss
@@ -65,3 +65,7 @@ h6, .h6 { font-size: $h6; }
   list-style: none;
   padding-left: 0px;
 }
+
+.noselect {
+  user-select: none;
+}


### PR DESCRIPTION
This would be nice for something I'm building for banking.  There's a routing number field, and the bank name appears on the right side of the field, kind of like a text field placeholder, but permanent:

![screenshot 2015-09-21 10 30 08](https://cloud.githubusercontent.com/assets/173215/9994539/c89902a4-604b-11e5-9588-6680835eb08e.png)

(ignore the error messages)

I think it would be nice to set `user-select: none` on this.  I can see this utility be used elsewhere, like on certain labels, etc.
