### PR TITLE
feat: upgrade namely-ui to use react v0.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "alt": "^0.17.1",
     "core-js": "^0.9.6",
     "node-fetch": "^1.3.2",
-    "react": "^0.12.1",
+    "react": "0.13.3",
     "react-select": "^0.4.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Right now namely/namely is using a branch of this repo called `react-upgrade` that was made to use the latest stable version of React for both this repo and the Namely app. Since DND, including the react upgrade, has been merged with develop and production, Namely/Namely is still using that outdated branch.

This PR is just to upgrade this repo to React v0.13.3 before changing namely/namely back to using the master branch. Once this is merged, a PR will be made on namely/namely to fix the package.json. 


Note:
I'll be making an issue for researching a better way of keep the React version between the two repos in sync. 