### PR TITLE
defines supported version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compile": "babel -d dist/ src/js/components/"
   },
   "engine": {
-    "node": ">=0.12.6"
+    "node": ">=4.2.1"
   },
   "author": "HipsterBrown",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "start": "gulp",
     "compile": "babel -d dist/ src/js/components/"
   },
+  "engine": {
+    "node": ">=0.12.6"
+  },
   "author": "HipsterBrown",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Similar to defining a ruby version in a Gemfile, defining a minimum version of node support will make sure we are aligned on our tooling to better catch dependency errors.

To upgrade node locally:
```
sudo npm cache clean -f
sudo npm install -g n
sudo n stable
```