### PR TITLE
updates gulp-sass to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-iconfont-css": "0.0.9",
     "gulp-json-sass": "hipsterbrown/gulp-json-sass",
     "gulp-minify-css": "^1.1.0",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.0.4",
     "gulp-scss-lint": "^0.2.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.4",


### PR DESCRIPTION
Was having trouble with node-sass when dealing with different, newer-ish versions of node. Traced it back to gulp-sass which could use a slight version bump to address performance / bugs.

*gulp-sass changelog*
https://github.com/dlmanning/gulp-sass/blob/master/CHANGELOG.md#v201

*depends on*
https://github.com/namely/styleguide/pull/182