### PR TITLE
Vertically Aligns Icons to the Middle

### DIFF
--- a/src/js/pages/icons.js
+++ b/src/js/pages/icons.js
@@ -10,8 +10,8 @@ export default React.createClass({
     return <Styleguide title="Icons">
       <div title="Names">
         {IconData.map(function(object, i){
-          return <div>
-            <Icon name={object.name} key={i} />
+          return <div key={i}>
+            <Icon name={object.name} />
             <code>.icon-{object.name}</code>
           </div>;
         })}

--- a/src/lib/scss/_icons-template.scss
+++ b/src/lib/scss/_icons-template.scss
@@ -17,6 +17,7 @@
   font-weight: normal;
   text-decoration: none;
   text-transform: none;
+  vertical-align: middle;
 }
 
 @function icon-char($filename) {

--- a/src/scss/base/_icons.scss
+++ b/src/scss/base/_icons.scss
@@ -17,6 +17,7 @@
   font-weight: normal;
   text-decoration: none;
   text-transform: none;
+  vertical-align: middle;
 }
 
 @function icon-char($filename) {


### PR DESCRIPTION
Adds `vertical-align: middle;` to `_icons-template.scss`.

***before***
![screen shot 2015-11-19 at 12 40 40 pm](https://cloud.githubusercontent.com/assets/471842/11278788/f819a950-8eba-11e5-8381-f7f6b7729af4.png)

***after***
![screen shot 2015-11-19 at 12 40 54 pm](https://cloud.githubusercontent.com/assets/471842/11278791/fe9496f0-8eba-11e5-8ed1-ff50940cfdf3.png)
