### PR TITLE
updates author and contributors in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,25 @@
   "engine": {
     "node": ">=4.2.1"
   },
-  "author": "HipsterBrown",
+  "author": "Namely <dev@namely.com",
+  "contributors": [{
+    "name": "Jason Fellows"
+  },
+  {
+    "name": "Katie Reed"
+  },
+  {
+    "name": "Keith Poplawski"
+  },
+  {
+    "name": "Nick Hehr"
+  },
+  {
+    "name": "Shelly Yip"
+  },
+  {
+    "name": "Tyler Sargent"
+  }],
   "license": "MIT",
   "dependencies": {
     "alt": "^0.17.1",


### PR DESCRIPTION
Just realized that I was still listed as the author of the namely-ui package, which is silly. This PR changes the `author` to Namely and lists everyone on the front-end team in the `contributors` field. Please let me know if I missed anyone. 