### PR TITLE
Add Chrome as a Karma browser option

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,6 +36,13 @@ module.exports = function(config) {
         })
       }
     },
+    
+    // change Karma's debug.html to the mocha web reporter
+    client: {
+      mocha: {
+        reporter: 'html'
+      }
+    },
 
     reporters: ['mocha'],
 
@@ -43,7 +50,8 @@ module.exports = function(config) {
       'karma-mocha',
       'karma-mocha-reporter',
       'karma-jsdom-launcher',
-      'karma-browserify'
+      'karma-browserify',
+      'karma-chrome-launcher'
     ],
 
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "jsdom": "^7.2.0",
     "karma": "^0.13.15",
     "karma-browserify": "^4.4.2",
+    "karma-chrome-launcher": "^0.2.0",    
     "karma-jsdom-launcher": "^1.0.1",
     "karma-mocha": "^0.2.1",
     "karma-mocha-reporter": "^1.1.3",


### PR DESCRIPTION
This copies the Karma setup by @johnnymo87 in the Namely app, and allows Karma to use Chrome with HTML reporting, for Chrome Dev Tools and this nice report:

![screen shot 2015-12-15 at 4 05 15 pm](https://cloud.githubusercontent.com/assets/2482212/11824086/b0ede42a-a345-11e5-9136-67353551f817.png)

This is still optional for the user and doesn't start automatically; command to use is
```
karma start --browsers Chrome
```