### PR TITLE
updates npmignore to include src/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 test/
-src/
 node_modules/
 site/
 public/


### PR DESCRIPTION
Since the npm script is now `postinstall`, `src/` needs to be included in the published package. 