### PR TITLE
fix postinstall

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 test/
-src/
 node_modules/
 site/
 public/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "styles": "./dist/namely-ui.css",
   "scripts": {
-    "postinstall": "./scripts/prepublish.sh",
+    "postinstall": "cp -r ./src/js/components/ ./",
     "start": "gulp",
     "test": "./node_modules/karma/bin/karma start --single-run=true"
   },
@@ -70,7 +70,7 @@
     "jsdom": "^7.2.0",
     "karma": "^0.13.15",
     "karma-browserify": "^4.4.2",
-    "karma-chrome-launcher": "^0.2.0",    
+    "karma-chrome-launcher": "^0.2.0",
     "karma-jsdom-launcher": "^1.0.1",
     "karma-mocha": "^0.2.1",
     "karma-mocha-reporter": "^1.1.3",

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-cp -r ./src/js/components/ ./
-
-


### PR DESCRIPTION
I think this fixes the postinstall.  `src/` should removed from `.npmignore` because the scripts moves files from that directory to the root.

I moved it right to the postinstall hook since it's just one command.

Please confirm this works before giving a plus one:

In your namely package.json, set the namely-ui dependency like this:
```
"namely-ui": "tsargent/styleguide#develop",
```

This will install namely-ui from my fork.  

Then do 
```shell
$ ls node_modules/namely-ui
```
from inside the namely app to confirm `buttons/`, `forms/` etc show up.