### PR TITLE
Fieldsets / Wells

### DIFF
--- a/src/js/components/forms/edit-label.es6
+++ b/src/js/components/forms/edit-label.es6
@@ -102,7 +102,7 @@ export default createClass({
   },
 
   _getTextClasses() {
-    var classes = ["field-light", "mr2", "py1", "h3", "bold", "no-resize", "flex-grow"];
+    var classes = ["mr2", "py1", "h3", "bold", "no-resize", "flex-grow"];
 
     if (this.state.hasErrors) {
       classes.push("bc-orange");

--- a/src/js/components/forms/fields/checkbox.es6
+++ b/src/js/components/forms/fields/checkbox.es6
@@ -9,7 +9,6 @@ export default React.createClass({
   propTypes: {
     disabled: Type.bool,
     extraClasses: Type.arrayOf(Type.string),
-    fieldColor: Type.oneOf(['light', 'dark']),
     label: Type.string.isRequired,
     placeholder: Type.string,
     readOnly: Type.bool,
@@ -20,7 +19,6 @@ export default React.createClass({
     return {
       checked: false,
       disabled: false,
-      fieldColor: 'light',
       readonly: false
     }
   },
@@ -33,12 +31,6 @@ export default React.createClass({
     if(!this.props.readOnly) {
       this.setState({isChecked: !this.state.isChecked})
     }
-  },
-
-  fieldClasses() {
-    var classes = [];
-    classes.push('field-'+this.props.fieldColor);
-    return classes.join(' ');
   },
 
   classes() {
@@ -56,15 +48,11 @@ export default React.createClass({
   render() {
     return <div className={this.classes()}>
         <label>
-          <input
-            checked={this.state.isChecked}
-            className={this.fieldClasses()}
-            disabled={this.props.disabled}
-            onChange={this.onChange}
-            readOnly={this.props.readOnly}
-            type="checkbox"
-          >
-          </input>
+          <input checked={this.state.isChecked}
+                 disabled={this.props.disabled}
+                 onChange={this.onChange}
+                 readOnly={this.props.readOnly}
+                 type="checkbox" />
           <span className="label-right">{this.props.label}</span>
         </label>
       </div>

--- a/src/js/components/forms/fields/date/date.es6
+++ b/src/js/components/forms/fields/date/date.es6
@@ -20,7 +20,6 @@ export default React.createClass({
     dateFormat: Type.oneOf(validDateFormats).isRequired,
     disabled: Type.bool,
     errors: Type.array,
-    fieldColor: Type.oneOf(['light', 'dark']),
     includeMaxMinBounds: Type.bool,
     initialValue: Type.oneOfType([Type.object, Type.string, Type.number]),
     label: Type.string,
@@ -35,7 +34,6 @@ export default React.createClass({
     return {
       disabled: false,
       errors: [],
-      fieldColor: 'light',
       includeMaxMinBounds: true,
       onChange: function() {}
     }
@@ -123,7 +121,6 @@ export default React.createClass({
 
   inputClasses() {
     let classes = ['relative', 'fit', 'pr4'];
-    classes.push( 'field-' + this.props.fieldColor );
     if (this.state.errors.length > 0) classes.push('bc-orange bw-2');
     return classes.join(' ');
   },

--- a/src/js/components/forms/fields/date/date.es6
+++ b/src/js/components/forms/fields/date/date.es6
@@ -113,12 +113,6 @@ export default React.createClass({
     return this.props.disabled || !this.isFormatValid();
   },
 
-  iconClasses() {
-    let classes = ['icon-calendar', 'ml1', 'absolute'];
-    this.disabled() ? classes.push('grey-25') : classes.push('blue-70');
-    return classes.join(' ');
-  },
-
   iconStyle() {
     return {
       right: '8px',
@@ -180,7 +174,7 @@ export default React.createClass({
                type="text"
                placeholder={this.props.placeholder}
                value={this.value()} />
-        <span className={this.iconClasses()}
+        <span className='icon-calendar ml1 absolute'
               onClick={this.showDatePicker}
               style={this.iconStyle()}></span>
       </div>

--- a/src/js/components/forms/fields/number.es6
+++ b/src/js/components/forms/fields/number.es6
@@ -9,7 +9,6 @@ export default React.createClass({
   propTypes: {
     disabled: Type.bool,
     extraClasses: Type.arrayOf(Type.string),
-    fieldColor: Type.oneOf(['light', 'dark']),
     label: Type.string,
     readOnly: Type.bool,
     units: Type.string
@@ -18,7 +17,6 @@ export default React.createClass({
   getDefaultProps() {
     return {
       readOnly: false,
-      fieldColor: 'light',
       inactive: false
     }
   },
@@ -41,12 +39,6 @@ export default React.createClass({
     return classes.join(' ');
   },
 
-  fieldClasses() {
-    var classes = [];
-    classes.push('field-'+this.props.fieldColor);
-    return classes.join(' ');
-  },
-
   classes() {
     var classes = ['number-field'];
     if(this.props.disabled) {
@@ -60,12 +52,9 @@ export default React.createClass({
     return  <div className={this.classes()}>
         {this.label()}
         <br/>
-        <input
-          className={this.fieldClasses()}
-          disabled={this.props.disabled}
-          type="number"
-          readOnly={this.props.readOnly}
-        ></input>
+        <input disabled={this.props.disabled}
+               type="number"
+               readOnly={this.props.readOnly}/>
         <span className='icon-arrow-double relative'></span>
         {this.units()}
       </div>

--- a/src/js/components/forms/fields/number.es6
+++ b/src/js/components/forms/fields/number.es6
@@ -41,12 +41,6 @@ export default React.createClass({
     return classes.join(' ');
   },
 
-  iconClasses() {
-    var classes = ['icon', 'icon-arrow-double'];
-    this.props.disabled ? classes.push('grey-25') : classes.push('blue-70');
-    return classes.join(' ');
-  },
-
   fieldClasses() {
     var classes = [];
     classes.push('field-'+this.props.fieldColor);
@@ -72,7 +66,7 @@ export default React.createClass({
           type="number"
           readOnly={this.props.readOnly}
         ></input>
-        <span className={this.iconClasses()}></span>
+        <span className='icon-arrow-double relative'></span>
         {this.units()}
       </div>
   }

--- a/src/js/components/forms/fields/radio.es6
+++ b/src/js/components/forms/fields/radio.es6
@@ -9,7 +9,6 @@ export default React.createClass({
   propTypes: {
     disabled: Type.bool,
     extraClasses: Type.arrayOf(Type.string),
-    fieldColor: Type.oneOf(['light', 'dark']),
     label: Type.string,
     readOnly: Type.bool,
     checked: Type.bool,
@@ -19,7 +18,6 @@ export default React.createClass({
   getDefaultProps() {
     return {
       disabled: false,
-      fieldColor: 'light',
       readonly: false,
       checked: false
     }
@@ -35,12 +33,6 @@ export default React.createClass({
     }
   },
 
-  fieldClasses() {
-    var classes = [];
-    classes.push('field-'+this.props.fieldColor);
-    return classes.join(' ');
-  },
-
   classes() {
     var classes = ['radio-field'];
     if(this.props.disabled) {
@@ -53,12 +45,9 @@ export default React.createClass({
   render() {
     return <div className={this.classes()}>
         <label>
-          <input
-            disabled={this.props.disabled}
-            className={this.fieldClasses()}
-            type="radio"
-            name={this.props.name}>
-          </input>
+          <input disabled={this.props.disabled}
+                 type="radio"
+                 name={this.props.name} />
           <span className="label-right">{this.props.label}</span>
         </label>
       </div>

--- a/src/js/components/forms/fields/select/select.es6
+++ b/src/js/components/forms/fields/select/select.es6
@@ -12,7 +12,6 @@ export default React.createClass({
     disabled: Type.bool,
     errors: Type.array,
     extraClasses: Type.array,
-    fieldColor: Type.oneOf(['light', 'dark']),
     includeBlank: Type.oneOfType([Type.bool, Type.string]),
     label: Type.string,
     name: Type.string,
@@ -26,7 +25,6 @@ export default React.createClass({
     return {
       disabled: false,
       errors: [],
-      fieldColor: 'light',
       onChange: function() {},
       value: null
     }
@@ -73,7 +71,6 @@ export default React.createClass({
         {this.label()}
         <SimpleSelect ref='simpleSelect'
                       disabled={this.props.disabled}
-                      fieldColor={this.props.fieldColor}
                       hasError={this.state.errors.length > 0}
                       includeBlank={this.props.includeBlank}
                       name={this.props.name}

--- a/src/js/components/forms/fields/select/select.es6
+++ b/src/js/components/forms/fields/select/select.es6
@@ -40,8 +40,11 @@ export default React.createClass({
   },
 
   containerClasses() {
-    let classes = ['relative'];
+    let classes = ['select-field', 'relative'];
     classes.push(this.props.extraClasses);
+    if (this.state.disabled) {
+      classes.push('disabled');
+    }
     return classes.join(' ');
   },
 
@@ -66,7 +69,7 @@ export default React.createClass({
 
   render() {
     return (
-      <div>
+      <div className={this.containerClasses()}>
         {this.label()}
         <SimpleSelect ref='simpleSelect'
                       disabled={this.props.disabled}

--- a/src/js/components/forms/fields/select/simple-select.es6
+++ b/src/js/components/forms/fields/select/simple-select.es6
@@ -50,7 +50,6 @@ export default React.createClass({
 
   arrowClasses() {
     let classes = ['h6', 'ml1', 'relative'];
-    classes.push(this.props.disabled ? 'grey-50' : 'blue-70');
     classes.push(this.state.show_options ? 'icon-arrow-up' : 'icon-arrow-down');
     return classes.join(' ');
   },

--- a/src/js/components/forms/fields/select/simple-select.es6
+++ b/src/js/components/forms/fields/select/simple-select.es6
@@ -10,7 +10,6 @@ export default React.createClass({
 
   propTypes: {
     disabled: Type.bool,
-    fieldColor: Type.oneOf(['light', 'dark']),
     hasError: Type.bool,
     includeBlank: Type.bool,
     name: Type.string,
@@ -22,7 +21,6 @@ export default React.createClass({
 
   getDefaultProps() {
     return {
-      fieldColor: 'light',
       hasError: false,
       onChange: function() {},
       options: []
@@ -164,12 +162,8 @@ export default React.createClass({
   valueBorderClass() {
     if (this.props.hasError) {
       return 'bc-orange bc-orange-hover';
-    } else if (this.props.disabled) {
-      return 'bc-grey-10';
     } else if (this.state.show_options) {
       return 'bc-grey-50';
-    } else {
-      return this.props.fieldColor == 'light' ? 'bc-grey-25' : 'bc-white';
     }
   },
 
@@ -179,7 +173,6 @@ export default React.createClass({
     classes.push(this.state.show_options ? 'rounded-top-2' : "rounded-2");
     if (this.props.disabled) {
       classes.push('disabled');
-      classes.push(this.props.fieldColor == 'light' ? 'grey-10 bg-grey-10' : 'grey-50 bg-grey-15');
     } else {
       classes.push('pointer bg-white');
     }

--- a/src/js/components/forms/fields/select/simple-select.es6
+++ b/src/js/components/forms/fields/select/simple-select.es6
@@ -189,7 +189,7 @@ export default React.createClass({
 
   render() {
     return (
-      <div className="relative simple-select">
+      <div className="relative">
         <input type="hidden"
                name={this.props.name}
                value={this.state.value}

--- a/src/js/components/forms/fields/text.es6
+++ b/src/js/components/forms/fields/text.es6
@@ -9,7 +9,6 @@ export default React.createClass({
   propTypes: {
     disabled: Type.bool,
     extraClasses: Type.arrayOf(Type.string),
-    fieldColor: Type.oneOf(['light', 'dark']),
     label: Type.string,
     placeholder: Type.string
   },
@@ -17,7 +16,6 @@ export default React.createClass({
   getDefaultProps() {
     return {
       disabled: false,
-      fieldColor: 'light',
       inactive: false,
       readOnly: false
     }
@@ -27,12 +25,6 @@ export default React.createClass({
     if(this.props.label) {
       return <label htmlFor={this.props.id} className="px2 mb1">{this.props.label}</label>;
     }
-  },
-
-  fieldClasses() {
-    var classes = [];
-    classes.push('field-'+this.props.fieldColor);
-    return classes.join(' ');
   },
 
   classes() {
@@ -47,13 +39,10 @@ export default React.createClass({
   render() {
     return  <div className={this.classes()}>
         {this.label()}
-        <input
-          className={this.fieldClasses()}
-          disabled={this.props.disabled}
-          type="text"
-          placeholder={this.props.placeholder}
-          readOnly={this.props.inactive || this.props.readOnly}
-        ></input>
+        <input disabled={this.props.disabled}
+               type="text"
+               placeholder={this.props.placeholder}
+               readOnly={this.props.inactive || this.props.readOnly} />
       </div>
   }
 });

--- a/src/js/components/forms/fields/textarea.es6
+++ b/src/js/components/forms/fields/textarea.es6
@@ -9,7 +9,6 @@ export default React.createClass({
   propTypes: {
     disabled: Type.bool,
     extraClasses: Type.arrayOf(Type.string),
-    fieldColor: Type.oneOf(['light', 'dark']),
     label: Type.string,
     placeholder: Type.string,
     readOnly: Type.bool,
@@ -18,7 +17,6 @@ export default React.createClass({
 
   getDefaultProps() {
     return {
-      fieldColor: 'light',
       readOnly: false,
       expandable: false
     }
@@ -33,13 +31,6 @@ export default React.createClass({
   expand(e) {
     e.target.style.height = "auto";
     e.target.style.height = e.target.scrollHeight + "px";
-  },
-
-  fieldClasses() {
-    var classes = [];
-    classes.push('field-' + this.props.fieldColor);
-    return classes.join(' ');
-
   },
 
   classes() {
@@ -58,13 +49,10 @@ export default React.createClass({
     return  <div className={this.classes()}>
         {this.label()}
         <br/>
-        <textarea
-          className={this.fieldClasses()}
-          disabled={this.props.disabled}
-          readOnly={this.props.readOnly}
-          placeholder={this.props.placeholder}
-          onChange={this.props.expandable ? this.expand : null}
-        />
+        <textarea disabled={this.props.disabled}
+                  readOnly={this.props.readOnly}
+                  placeholder={this.props.placeholder}
+                  onChange={this.props.expandable ? this.expand : null} />
       </div>
   }
 });

--- a/src/js/components/overlays/tooltip.es6
+++ b/src/js/components/overlays/tooltip.es6
@@ -15,7 +15,6 @@ export default React.createClass({
   displayName: "Tooltip",
 
   propTypes: {
-    animate: Type.bool,
     caretPosition: Type.oneOf(caretPositions),
     closeOverlay: Type.func,
     content: Type.node.isRequired,
@@ -28,7 +27,6 @@ export default React.createClass({
 
   getDefaultProps() {
     return {
-      animate: true,
       bottom: null,
       caretPosition: 'top-right',
       closeOverlay: function() {},

--- a/src/js/pages/forms.js
+++ b/src/js/pages/forms.js
@@ -93,82 +93,81 @@ export default React.createClass({
           <form className="clearfix">
             <hr />
             <p>Default fields</p>
-            <TextField label="Text" fieldColor='light' placeholder="Placeholder" extraClasses={['py2']} />
-            <NumberField label="Number" fieldColor='light' extraClasses={['py2']} units="Units"  />
+            <TextField label="Text" placeholder="Placeholder" extraClasses={['py2']} />
+            <NumberField label="Number" extraClasses={['py2']} units="Units"  />
             <DateField dateFormat='MMM D, YYYY'
                        extraClasses={['py2']}
-                       fieldColor='light'
                        label='Date'
                        placeholder="Placeholder" />
             <div className='clearfix'></div>
-            <SelectField label="Select" fieldColor='light' options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
-            <TextArea label="Textarea" fieldColor='light'  extraClasses={['py2']} />
-            <TextArea label="Textarea Expandable" fieldColor='light' expandable={true} extraClasses={['py2']} />
-            <Checkbox label="Checkbox" fieldColor='light' extraClasses={['py2']}/>
-            <Checkbox label="Checked read-only" fieldColor='light' readOnly={true} checked={true} extraClasses={['py2']}/>
-            <Radio name="radios1" fieldColor='light' label="Radio 1" extraClasses={['py2']}/>
-            <Radio name="radios1" fieldColor='light' label="Radio 2" extraClasses={['py2']}/>
+            <SelectField label="Select" options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
+            <TextArea label="Textarea" extraClasses={['py2']} />
+            <TextArea label="Textarea Expandable" expandable={true} extraClasses={['py2']} />
+            <Checkbox label="Checkbox" extraClasses={['py2']}/>
+            <Checkbox label="Checked read-only" readOnly={true} checked={true} extraClasses={['py2']}/>
+            <Radio name="radios1" label="Radio 1" extraClasses={['py2']}/>
+            <Radio name="radios1" label="Radio 2" extraClasses={['py2']}/>
 
             <p className="mt4">Disabled fields</p>
-            <TextField label="Text" fieldColor='light' placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
-            <NumberField label="Number" fieldColor='light' disabled={true} extraClasses={['py2']} />
-            <DateField date="2015/1/1" label="ReactDate" fieldColor='light' disabled={true} extraClasses={['py2']} dateFormat='YYYY/MM/DD'/>
+            <TextField label="Text" placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
+            <NumberField label="Number" disabled={true} extraClasses={['py2']} />
+            <DateField date="2015/1/1" label="ReactDate" disabled={true} extraClasses={['py2']} dateFormat='YYYY/MM/DD'/>
             <div className='clearfix'></div>
-            <SelectField label="Simple Select" fieldColor='light' options={simpleSelectOptions1} disabled={true} extraClasses={['py2']}/>
-            <TextArea label="Textarea" fieldColor='light'  disabled={true} extraClasses={['py2']} />
-            <Checkbox label="Checkbox" fieldColor='light' disabled={true} extraClasses={['py2']}/>
-            <Radio name="radios2" fieldColor='light' label="Radio" disabled={true} extraClasses={['py2']} />
+            <SelectField label="Simple Select" options={simpleSelectOptions1} disabled={true} extraClasses={['py2']}/>
+            <TextArea label="Textarea"  disabled={true} extraClasses={['py2']} />
+            <Checkbox label="Checkbox" disabled={true} extraClasses={['py2']}/>
+            <Radio name="radios2" label="Radio" disabled={true} extraClasses={['py2']} />
 
             <p className="mt4">Fields within fieldset</p>
             <fieldset>
               <p>Default fields</p>
-              <TextField label="Text" fieldColor='dark' placeholder="Placeholder" extraClasses={['py2']}/>
-              <NumberField label="Number" fieldColor='dark' extraClasses={['py2']} units="Units" />
-              <DateField label="Date" fieldColor='dark' extraClasses={['py2']} dateFormat='MMM D, YYYY'/>
+              <TextField label="Text" placeholder="Placeholder" extraClasses={['py2']}/>
+              <NumberField label="Number" extraClasses={['py2']} units="Units" />
+              <DateField label="Date" extraClasses={['py2']} dateFormat='MMM D, YYYY'/>
               <div className='clearfix'></div>
-              <SelectField label="Simple Select" fieldColor='dark' options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
-              <TextArea label="Textarea" fieldColor='dark' extraClasses={['py2']}/>
-              <Checkbox label="Checkbox" fieldColor='dark' extraClasses={['py2']}/>
-              <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
-              <Radio name="radios3" fieldColor='dark' label="Radio 1" extraClasses={['py2']}/>
-              <Radio name="radios3" fieldColor='dark' label="Radio 2" extraClasses={['py2']}/>
+              <SelectField label="Simple Select" options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
+              <TextArea label="Textarea" extraClasses={['py2']}/>
+              <Checkbox label="Checkbox" extraClasses={['py2']}/>
+              <Checkbox label="Checked read-only" readOnly={true} checked={true} extraClasses={['py2']}/>
+              <Radio name="radios3" label="Radio 1" extraClasses={['py2']}/>
+              <Radio name="radios3" label="Radio 2" extraClasses={['py2']}/>
               <hr />
               <p>Disabled fields</p>
-              <TextField label="Text" fieldColor='dark' placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
-              <NumberField label="Number" fieldColor='dark' disabled={true} extraClasses={['py2']} />
-              <DateField label="ReactDate" fieldColor='dark' disabled={true} extraClasses={['py2']} dateFormat='MMM D, YYYY' />
+              <TextField label="Text" placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
+              <NumberField label="Number" disabled={true} extraClasses={['py2']} />
+              <DateField label="ReactDate" disabled={true} extraClasses={['py2']} dateFormat='MMM D, YYYY' />
               <div className='clearfix'></div>
-              <SelectField label="Simple Select" fieldColor='dark' options={simpleSelectOptions1} disabled={true} extraClasses={['py2']}/>
-              <TextArea label="Textarea" fieldColor='dark' disabled={true} extraClasses={['py2']} />
-              <Checkbox label="Checkbox" fieldColor='dark' disabled={true} extraClasses={['py2']}/>
-              <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
-              <Radio name="radios2" fieldColor='dark' label="Radio" disabled={true} extraClasses={['py2']} />
+              <SelectField label="Simple Select" options={simpleSelectOptions1} disabled={true} extraClasses={['py2']}/>
+              <TextArea label="Textarea" disabled={true} extraClasses={['py2']} />
+              <Checkbox label="Checkbox" disabled={true} extraClasses={['py2']}/>
+              <Checkbox label="Checked read-only" readOnly={true} checked={true} extraClasses={['py2']}/>
+              <Radio name="radios2" label="Radio" disabled={true} extraClasses={['py2']} />
             </fieldset>
 
             <p className="mt4">Fields within tooltip</p>
             <div className="tooltip rounded-3 p2 bg-blue-95">
               <p className="grey-10">Default fields</p>
-              <TextField label="Text" fieldColor='dark' placeholder="Placeholder" extraClasses={['py2']}/>
-              <NumberField label="Number" fieldColor='dark' extraClasses={['py2']} units="Units" />
-              <DateField label="Date" fieldColor='dark' extraClasses={['py2']} dateFormat='MMM D, YYYY'/>
+              <TextField label="Text" placeholder="Placeholder" extraClasses={['py2']}/>
+              <NumberField label="Number" extraClasses={['py2']} units="Units" />
+              <DateField label="Date" extraClasses={['py2']} dateFormat='MMM D, YYYY'/>
               <div className='clearfix'></div>
-              <SelectField label="Simple Select" fieldColor='dark' options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
-              <TextArea label="Textarea" fieldColor='dark' extraClasses={['py2']}/>
-              <Checkbox label="Checkbox" fieldColor='dark' extraClasses={['py2']}/>
-              <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
-              <Radio name="radios3" fieldColor='dark' label="Radio 1" extraClasses={['py2']}/>
-              <Radio name="radios3" fieldColor='dark' label="Radio 2" extraClasses={['py2']}/>
+              <SelectField label="Simple Select" options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
+              <TextArea label="Textarea" extraClasses={['py2']}/>
+              <Checkbox label="Checkbox" extraClasses={['py2']}/>
+              <Checkbox label="Checked read-only" readOnly={true} checked={true} extraClasses={['py2']}/>
+              <Radio name="radios3" label="Radio 1" extraClasses={['py2']}/>
+              <Radio name="radios3" label="Radio 2" extraClasses={['py2']}/>
               <hr />
               <p className="grey-10">Disabled fields</p>
-              <TextField label="Text" fieldColor='dark' placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
-              <NumberField label="Number" fieldColor='dark' disabled={true} extraClasses={['py2']} />
-              <DateField label="ReactDate" fieldColor='dark' disabled={true} extraClasses={['py2']} dateFormat='MMM D, YYYY' />
+              <TextField label="Text" placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
+              <NumberField label="Number" disabled={true} extraClasses={['py2']} />
+              <DateField label="ReactDate" disabled={true} extraClasses={['py2']} dateFormat='MMM D, YYYY' />
               <div className='clearfix'></div>
-              <SelectField label="Simple Select" fieldColor='dark' options={simpleSelectOptions1} disabled={true} extraClasses={['py2']}/>
-              <TextArea label="Textarea" fieldColor='dark' disabled={true} extraClasses={['py2']} />
-              <Checkbox label="Checkbox" fieldColor='dark' disabled={true} extraClasses={['py2']}/>
-              <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
-              <Radio name="radios2" fieldColor='dark' label="Radio" disabled={true} extraClasses={['py2']} />
+              <SelectField label="Simple Select" options={simpleSelectOptions1} disabled={true} extraClasses={['py2']}/>
+              <TextArea label="Textarea" disabled={true} extraClasses={['py2']} />
+              <Checkbox label="Checkbox" disabled={true} extraClasses={['py2']}/>
+              <Checkbox label="Checked read-only" readOnly={true} checked={true} extraClasses={['py2']}/>
+              <Radio name="radios2" label="Radio" disabled={true} extraClasses={['py2']} />
             </div>
 
             <hr />
@@ -311,12 +310,10 @@ export default React.createClass({
         <div title="Date Fields">
           <DateField dateFormat='MMM D, YYYY'
                      extraClasses={['py2']}
-                     fieldColor='light'
                      value={new Date} />
           <div className='clearfix'></div>
           <DateField dateFormat='MMM D, YYYY'
                      extraClasses={['py2']}
-                     fieldColor='light'
                      label="With Min/Max Dates"
                      maxDate={this.pushPullToday(35)}
                      minDate={this.pushPullToday(-5)}
@@ -324,13 +321,11 @@ export default React.createClass({
           <div className='clearfix'></div>
           <DateField dateFormat='MMM D, YYY'
                      extraClasses={['py2']}
-                     fieldColor='light'
                      label="With bad format string" />
           <div className='clearfix'></div>
           <DateField dateFormat='MMM D, YYYY'
                      errors={['You broke it!', 'Time is irrelevant']}
                      extraClasses={['py2']}
-                     fieldColor='light'
                      label="With errors" />
           <div className='clearfix'></div>
         </div>

--- a/src/js/pages/forms.js
+++ b/src/js/pages/forms.js
@@ -119,8 +119,8 @@ export default React.createClass({
             <Checkbox label="Checkbox" fieldColor='light' disabled={true} extraClasses={['py2']}/>
             <Radio name="radios2" fieldColor='light' label="Radio" disabled={true} extraClasses={['py2']} />
 
-            <p className="mt4">Fields within grey block</p>
-            <div className="bg-grey-10 p3 rounded-3">
+            <p className="mt4">Fields within fieldset</p>
+            <fieldset>
               <p>Default fields</p>
               <TextField label="Text" fieldColor='dark' placeholder="Placeholder" extraClasses={['py2']}/>
               <NumberField label="Number" fieldColor='dark' extraClasses={['py2']} units="Units" />
@@ -143,7 +143,7 @@ export default React.createClass({
               <Checkbox label="Checkbox" fieldColor='dark' disabled={true} extraClasses={['py2']}/>
               <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
               <Radio name="radios2" fieldColor='dark' label="Radio" disabled={true} extraClasses={['py2']} />
-            </div>
+            </fieldset>
 
             <hr />
 

--- a/src/js/pages/forms.js
+++ b/src/js/pages/forms.js
@@ -132,7 +132,7 @@ export default React.createClass({
               <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
               <Radio name="radios3" fieldColor='dark' label="Radio 1" extraClasses={['py2']}/>
               <Radio name="radios3" fieldColor='dark' label="Radio 2" extraClasses={['py2']}/>
-              <hr className="bc-white"/>
+              <hr />
               <p>Disabled fields</p>
               <TextField label="Text" fieldColor='dark' placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
               <NumberField label="Number" fieldColor='dark' disabled={true} extraClasses={['py2']} />
@@ -144,6 +144,32 @@ export default React.createClass({
               <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
               <Radio name="radios2" fieldColor='dark' label="Radio" disabled={true} extraClasses={['py2']} />
             </fieldset>
+
+            <p className="mt4">Fields within tooltip</p>
+            <div className="tooltip rounded-3 p2 bg-blue-95">
+              <p className="grey-10">Default fields</p>
+              <TextField label="Text" fieldColor='dark' placeholder="Placeholder" extraClasses={['py2']}/>
+              <NumberField label="Number" fieldColor='dark' extraClasses={['py2']} units="Units" />
+              <DateField label="Date" fieldColor='dark' extraClasses={['py2']} dateFormat='MMM D, YYYY'/>
+              <div className='clearfix'></div>
+              <SelectField label="Simple Select" fieldColor='dark' options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
+              <TextArea label="Textarea" fieldColor='dark' extraClasses={['py2']}/>
+              <Checkbox label="Checkbox" fieldColor='dark' extraClasses={['py2']}/>
+              <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
+              <Radio name="radios3" fieldColor='dark' label="Radio 1" extraClasses={['py2']}/>
+              <Radio name="radios3" fieldColor='dark' label="Radio 2" extraClasses={['py2']}/>
+              <hr />
+              <p className="grey-10">Disabled fields</p>
+              <TextField label="Text" fieldColor='dark' placeholder="Placeholder" disabled={true} extraClasses={['py2']} />
+              <NumberField label="Number" fieldColor='dark' disabled={true} extraClasses={['py2']} />
+              <DateField label="ReactDate" fieldColor='dark' disabled={true} extraClasses={['py2']} dateFormat='MMM D, YYYY' />
+              <div className='clearfix'></div>
+              <SelectField label="Simple Select" fieldColor='dark' options={simpleSelectOptions1} disabled={true} extraClasses={['py2']}/>
+              <TextArea label="Textarea" fieldColor='dark' disabled={true} extraClasses={['py2']} />
+              <Checkbox label="Checkbox" fieldColor='dark' disabled={true} extraClasses={['py2']}/>
+              <Checkbox label="Checked read-only" fieldColor='dark' readOnly={true} checked={true} extraClasses={['py2']}/>
+              <Radio name="radios2" fieldColor='dark' label="Radio" disabled={true} extraClasses={['py2']} />
+            </div>
 
             <hr />
 

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -361,6 +361,7 @@ fieldset {
 }
 
 .checkbox-field, .radio-field {
+  margin-right: $space-4;
 
   &.read-only, &.inactive {
 
@@ -372,19 +373,12 @@ fieldset {
   .label-right {
     margin-left: $space-2;
     position: relative;
+    top: -4px;
   }
 
   &.inactive input {
     background: none;
   }
-}
-
-.checkbox-field .label-right {
-  top: -4px;
-}
-
-.radio-field .label-right {
-  top: -4px;
 }
 
 .simple-select {

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -2,22 +2,17 @@ input,
 select,
 textarea {
   -webkit-appearance: none;
-  border-radius: 3px;
   font-family: $sans-family;
   font-size: $h5;
   margin-bottom: 0;
   margin-top: 0;
 
-  &.disabled,
-  &:disabled {
-    background: $grey-10;
-    border: 1px solid $grey-10;
+  &::placeholder {
     color: $grey-50;
+  }
 
-    &:focus,
-    &:hover {
-      border: 1px solid $grey-10;
-    }
+  &:not([readonly]):focus::placeholder {
+    color: transparent;
   }
 
   &:focus {
@@ -25,8 +20,20 @@ textarea {
   }
 
   &.bc-orange {
-    border-color: $orange;
+    border-color: $orange !important;
   }
+}
+
+label {
+  color: $grey-50;
+  cursor: pointer;
+  display: inline-block;
+  font-size: $h6;
+  line-height: 1;
+}
+
+.disabled label {
+  cursor: default;
 }
 
 [type=text],
@@ -44,24 +51,18 @@ textarea {
 .date-field input,
 textarea {
   background: $blue-05;
-  border: 1px solid $blue-05;
+  border-width: 1px;
+  border-style: solid;
   border-radius: 3px;
   box-sizing: border-box;
   color: $grey-75;
   vertical-align: middle;
   width: 100%;
 
-  &:focus:not([readonly]),
-  &:hover:not([readonly]) {
-    border-color: $blue-25;
-  }
-}
-
-.date-field input {
-
-  &:focus,
-  &:hover {
-    border-color: $blue-25;
+  &.disabled,
+  &:disabled {
+    background: $grey-10;
+    color: $grey-50;
   }
 }
 
@@ -77,13 +78,47 @@ textarea {
 [type=time],
 [type=url],
 [type=week],
-.date-field input {
-  padding: $space-1;
+textarea {
+  border-color: $blue-05;
+
+  &:focus:not([readonly]),
+  &:hover:not([readonly]) {
+    border-color: $blue-25;
+  }
+
+  &:disabled,
+  &.disabled {
+    border-color: $grey-10;
+
+    &:focus:not([readonly]),
+    &:hover:not([readonly]) {
+      border-color: $grey-10;
+    }
+  }
 }
 
-[type=checkbox],
-[type=radio],
-select {
+// Date field inputs are always read-only
+.date-field input {
+  border-color: $blue-05;
+
+  &:focus,
+  &:hover {
+    border-color: $blue-25;
+  }
+
+  &.disabled,
+  &:disabled {
+    border-color: $grey-10;
+
+    &:focus,
+    &:hover {
+      border-color: $grey-10;
+    }
+  }
+}
+
+select,
+.simple-select {
   background: $white;
   border: 1px solid $grey-25;
 
@@ -93,54 +128,12 @@ select {
   }
 }
 
-input::placeholder {
-  color: $grey-50;
-}
-
-input:not([readonly]):focus::placeholder {
-  color: transparent;
-}
-
-select {
-  height: $space-4;
-  min-width: 100%;
-  padding: $space-1;
-
-  &:not([multiple]) {
-    vertical-align: middle;
-  }
-}
-
-textarea {
-  padding: $space-2;
-}
-
-[type=number]::-webkit-inner-spin-button,
-[type=number]::-webkit-outer-spin-button {
-  opacity: 0;
-}
-
 [type=checkbox] {
   background: none;
   border: 0;
   height: $space-3;
   position: relative;
   width: $space-3;
-
-  &:disabled:after {
-    background: $grey-10;
-    border: 1px solid $grey-10;
-    border-radius: 3px;
-    content: '';
-    cursor: default;
-
-  }
-
-  &[readonly]:after {
-    background: none;
-    border: 0;
-    cursor: default;
-  }
 
   &:after {
     border: 1px solid $grey-15;
@@ -153,6 +146,20 @@ textarea {
     position: absolute;
     width: $space-3;
     z-index: 1;
+  }
+
+  &:disabled:after {
+    background: $grey-10;
+    border-color: $grey-10;
+    border-radius: 3px;
+    content: '';
+    cursor: default;
+  }
+
+  &[readonly]:after {
+    background: none;
+    border: 0;
+    cursor: default;
   }
 
   &:hover:after {
@@ -189,18 +196,9 @@ textarea {
   background: none;
   border: 0;
 
-  &:disabled:after {
-    cursor: default;
-    background: $grey-10;
-    border: 1px solid $grey-10;
-  }
-
-  &:disabled:hover:after {
-    border-color: $grey-10;
-  }
-
   &:after {
     border-radius: 50%;
+    border: 1px solid $grey-15;
     color: $grey-50;
     content: '';
     cursor: pointer;
@@ -210,7 +208,16 @@ textarea {
     position: absolute;
     top: 3px;
     width: 14px;
-    border: 1px solid $grey-15;
+  }
+
+  &:disabled:after {
+    cursor: default;
+    background: $grey-10;
+    border-color: $grey-10;
+  }
+
+  &:disabled:hover:after {
+    border-color: $grey-15;
   }
 
   &:hover:after {
@@ -232,109 +239,300 @@ textarea {
   }
 }
 
-label {
-  color: $grey-50;
-  cursor: pointer;
-  display: inline-block;
-  font-size: $h6;
-  line-height: 1;
-}
-
-.disabled label {
-  cursor: default;
-}
-
 fieldset {
   background-color: $grey-10;
   border: 0;
   border-radius: 6px;
   padding: $space-3;
 
-  input,
-  select,
-  textarea,
-  .simple-select {
+  [type=text],
+  [type=datetime],
+  [type=datetime-local],
+  [type=email],
+  [type=month],
+  [type=number],
+  [type=password],
+  [type=search],
+  [type=tel],
+  [type=time],
+  [type=url],
+  [type=week],
+  .simple-select,
+  textarea {
+    background-color: $white;
 
-    &:hover {
+    &:focus:not([readonly]),
+    &:hover:not([readonly]) {
+      border-color: $grey-50;
+    }
 
+    &.disabled,
+    &:disabled {
+      background: $grey-15;
+      border-color: $grey-15;
+      color: $grey-50;
+
+      &:focus:not([readonly]),
+      &:hover:not([readonly]) {
+        border-color: $grey-15;
+      }
     }
   }
 
-  label {
+  .date-field input {
+    background-color: $white;
 
+    &:focus,
+    &:hover {
+      border-color: $grey-50;
+    }
+
+    &.disabled,
+    &:disabled {
+      background: $grey-15;
+      border-color: $grey-15;
+      color: $grey-50;
+
+      &:focus,
+      &:hover {
+        border-color: $grey-15;
+      }
+    }
+  }
+
+  [type=checkbox],
+  [type=radio] {
+
+    &:after {
+      background-color: $white;
+      border-color: $white;
+    }
+
+    &:disabled:after {
+      background-color: $grey-15;
+      border-color: $grey-15;
+
+      &:focus:not([readonly]),
+      &:hover:not([readonly]) {
+        border-color: $grey-15;
+      }
+    }
+  }
+
+  hr {
+    border-color: $grey-25;
   }
 }
 
+.modal,
+.popContainer,
 .tooltip {
 
-  input,
-  select,
-  textarea,
-  .simple-select {
+  [type=text],
+  [type=datetime],
+  [type=datetime-local],
+  [type=email],
+  [type=month],
+  [type=number],
+  [type=password],
+  [type=search],
+  [type=tel],
+  [type=time],
+  [type=url],
+  [type=week],
+  textarea {
 
-    &:hover {
+    &:focus:not([readonly]),
+    &:hover:not([readonly]) {
+      border-color: $blue-50;
+    }
 
+    &.disabled,
+    &:disabled {
+      background-color: $grey-75;
+      border-color: $grey-75;
+      color: $grey-50;
+
+      &:focus:not([readonly]),
+      &:hover:not([readonly]) {
+        border-color: $grey-75;
+      }
     }
   }
 
-  label {
+  .simple-select {
 
+    &.disabled,
+    &:disabled {
+      background-color: $grey-75;
+      border-color: $grey-75;
+      color: $grey-50;
+
+      &:focus:not([readonly]),
+      &:hover:not([readonly]) {
+        border-color: $grey-75;
+      }
+    }
+
+    &:focus:not([readonly]),
+    &:hover:not([readonly]) {
+      border-color: $blue-50;
+    }
+  }
+
+  .date-field input {
+
+    &:focus,
+    &:hover {
+      border-color: $blue-50;
+    }
+
+    &.disabled,
+    &:disabled {
+      background: $grey-75;
+      border-color: $grey-75;
+      color: $grey-75;
+
+      &:focus,
+      &:hover {
+        border-color: $grey-75;
+      }
+    }
+  }
+
+  [type=checkbox],
+  [type=radio] {
+
+    &:after {
+      background-color: $white;
+      border-color: $grey-75;
+
+      &:focus:not([readonly]),
+      &:hover:not([readonly]) {
+        border-color: $blue-50;
+      }
+    }
+
+    &[readonly]:after {
+      background-color: $blue-95;
+    }
+
+    &:disabled:after {
+      background-color: $grey-75;
+      border-color: $grey-75;
+
+      &:focus:not([readonly]),
+      &:hover:not([readonly]) {
+        border-color: $grey-75;
+      }
+    }
+  }
+
+  hr {
+    border-color: $grey-75;
   }
 }
 
-// fields on dark background (grey form)
+// All inputs except checkbox, radio, select, and textarea
+[type=text],
+[type=datetime],
+[type=datetime-local],
+[type=email],
+[type=month],
+[type=number],
+[type=password],
+[type=search],
+[type=tel],
+[type=time],
+[type=url],
+[type=week],
+.date-field input {
+  padding: $space-1;
+}
 
-.field-dark {
-  background: $white;
-  border: 1px solid $white;
+textarea {
+  padding: $space-2;
+}
 
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
+  opacity: 0;
+}
+
+// Field icon colors
+.number-field,
+.select-field {
+
+  .icon-arrow-double,
+  .icon-arrow-down,
+  .icon-arrow-up {
+    color: $blue-50;
+  }
+
+  &:focus:not([readonly]),
+  &:hover:not([readonly]) {
+
+    .icon-arrow-double,
+    .icon-arrow-down,
+    .icon-arrow-up {
+      color: $blue-70;
+    }
+
+    &.disabled,
+    &.disabled:focus,
+    &.disabled:hover {
+
+      .icon-arrow-double,
+      .icon-arrow-down,
+      .icon-arrow-up {
+        color: $grey-50;
+      }
+    }
+  }
+
+  &.disabled,
+  &.disabled:focus,
+  &.disabled:hover {
+
+    .icon-arrow-double,
+    .icon-arrow-down,
+    .icon-arrow-up {
+      color: $grey-50;
+    }
+  }
+}
+
+.date-field {
+
+  .icon-calendar {
+    color: $blue-50;
+  }
+
+  &:focus,
   &:hover {
-    border: 1px solid $grey-50;
+
+    .icon-calendar {
+      color: $blue-70;
+    }
+
+    &.disabled,
+    &.disabled:focus,
+    &.disabled:hover {
+
+      .icon-calendar {
+        color: $grey-50;
+      }
+    }
   }
-}
 
-.field-dark:disabled {
-  background: $grey-15;
-  border: 1px solid $grey-15;
+  &.disabled,
+  &.disabled:focus,
+  &.disabled:hover {
 
-  &:hover {
-    border: 1px solid $grey-15;
+    .icon-calendar {
+      color: $grey-50;
+    }
   }
-}
-
-.field-dark[type=checkbox] {
-  background: none;
-  border: 0;
-}
-
-.field-dark[type=checkbox]:after {
-  background: $white;
-  border: 1px solid $white;
-}
-
-.field-dark[type=checkbox]:disabled:after {
-  background: $grey-15;
-  border: 1px solid $grey-15;
-}
-
-.field-dark[type=checkbox][readonly]:after {
-  background: none;
-  border: 0;
-}
-
-.field-dark[type=radio] {
-  background: none;
-  border: 0;
-}
-
-.field-dark[type=radio]:after {
-  background: $white;
-  border: 1px solid $white;
-}
-
-.field-dark[type=radio]:disabled:after {
-  background: $grey-15;
-  border: 1px solid $grey-15;
 }
 
 // note: there are some very pixel-specific styles here,
@@ -342,12 +540,11 @@ fieldset {
 
 .number-field {
 
-  .icon {
+  .icon-arrow-double {
     font-size: 14px;
     height: 0;
     margin-left: -20px;
     pointer-events: none;
-    position: relative;
     width: 0;
   }
 
@@ -360,10 +557,12 @@ fieldset {
   }
 }
 
-.checkbox-field, .radio-field {
+.checkbox-field,
+.radio-field {
   margin-right: $space-4;
 
-  &.read-only, &.inactive {
+  &.read-only,
+  &.inactive {
 
     label {
       cursor: default;
@@ -388,7 +587,7 @@ fieldset {
   }
 
   &.disabled:hover {
-    border-color: $grey-15;
+    border-color: $grey-10;
   }
 
   &.bc-orange-hover:hover {

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -58,6 +58,44 @@ label {
   line-height: 1;
 }
 
+fieldset {
+  background-color: $grey-10;
+  border: 0;
+  border-radius: 6px;
+  padding: $space-3;
+
+  input,
+  select,
+  textarea,
+  .simple-select {
+
+    &:hover {
+
+    }
+  }
+
+  label {
+
+  }
+}
+
+.tooltip {
+
+  input,
+  select,
+  textarea,
+  .simple-select {
+
+    &:hover {
+
+    }
+  }
+
+  label {
+
+  }
+}
+
 [type=text],
 [type=datetime],
 [type=datetime-local],

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -406,11 +406,11 @@ fieldset {
     &:after {
       background-color: $white;
       border-color: $grey-75;
+    }
 
-      &:focus:not([readonly]),
-      &:hover:not([readonly]) {
-        border-color: $blue-50;
-      }
+    &:focus:not([readonly]):after,
+    &:hover:not([readonly]):after {
+      border-color: $blue-50;
     }
 
     &[readonly]:after {
@@ -420,11 +420,11 @@ fieldset {
     &:disabled:after {
       background-color: $grey-75;
       border-color: $grey-75;
+    }
 
-      &:focus:not([readonly]),
-      &:hover:not([readonly]) {
-        border-color: $grey-75;
-      }
+    &:focus:not([readonly]):disabled:after,
+    &:hover:not([readonly]):disabled:after {
+      border-color: $grey-75;
     }
   }
 

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -1,12 +1,24 @@
 input,
 select,
-textarea,
-.simple-select,
-fieldset {
+textarea {
+  -webkit-appearance: none;
+  border-radius: 3px;
   font-family: $sans-family;
   font-size: $h5;
   margin-bottom: 0;
   margin-top: 0;
+
+  &.disabled,
+  &:disabled {
+    background: $grey-10;
+    border: 1px solid $grey-10;
+    color: $grey-50;
+
+    &:focus,
+    &:hover {
+      border: 1px solid $grey-10;
+    }
+  }
 
   &:focus {
     outline: 0;
@@ -14,6 +26,70 @@ fieldset {
 
   &.bc-orange {
     border-color: $orange;
+  }
+}
+
+[type=text],
+[type=datetime],
+[type=datetime-local],
+[type=email],
+[type=month],
+[type=number],
+[type=password],
+[type=search],
+[type=tel],
+[type=time],
+[type=url],
+[type=week],
+.date-field input,
+textarea {
+  background: $blue-05;
+  border: 1px solid $blue-05;
+  border-radius: 3px;
+  box-sizing: border-box;
+  color: $grey-75;
+  vertical-align: middle;
+  width: 100%;
+
+  &:focus:not([readonly]),
+  &:hover:not([readonly]) {
+    border-color: $blue-25;
+  }
+}
+
+.date-field input {
+
+  &:focus,
+  &:hover {
+    border-color: $blue-25;
+  }
+}
+
+[type=text],
+[type=datetime],
+[type=datetime-local],
+[type=email],
+[type=month],
+[type=number],
+[type=password],
+[type=search],
+[type=tel],
+[type=time],
+[type=url],
+[type=week],
+.date-field input {
+  padding: $space-1;
+}
+
+[type=checkbox],
+[type=radio],
+select {
+  background: $white;
+  border: 1px solid $grey-25;
+
+  &:focus,
+  &:hover {
+    border-color: $grey-50;
   }
 }
 
@@ -26,27 +102,133 @@ input:not([readonly]):focus::placeholder {
 }
 
 select {
-  -webkit-appearance: none;
-  border-radius: 3px;
   height: $space-4;
-  min-width: 100%; // fill the container, preferably a col-* class
+  min-width: 100%;
   padding: $space-1;
-}
 
-select:not([multiple]) {
-  vertical-align: middle;
+  &:not([multiple]) {
+    vertical-align: middle;
+  }
 }
 
 textarea {
-  border-radius: 3px;
-  box-sizing: border-box;
   padding: $space-2;
-  vertical-align: middle;
-  width: 100%;
+}
 
-  &:not([readonly]):focus,
-  &:not([readonly]):hover {
-    border: 1px solid $blue-25;
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
+  opacity: 0;
+}
+
+[type=checkbox] {
+  background: none;
+  border: 0;
+  height: $space-3;
+  position: relative;
+  width: $space-3;
+
+  &:disabled:after {
+    background: $grey-10;
+    border: 1px solid $grey-10;
+    border-radius: 3px;
+    content: '';
+    cursor: default;
+
+  }
+
+  &[readonly]:after {
+    background: none;
+    border: 0;
+    cursor: default;
+  }
+
+  &:after {
+    border: 1px solid $grey-15;
+    border-radius: 3px;
+    color: $grey-50;
+    content: '';
+    cursor: pointer;
+    display: block;
+    height: $space-3;
+    position: absolute;
+    width: $space-3;
+    z-index: 1;
+  }
+
+  &:hover:after {
+    border-color: $grey-50;
+  }
+
+  &:checked {
+    @include icon(check);
+
+    &:before {
+      color: $grey-50;
+      font-size: $h6;
+      left: 3px;
+      position: absolute;
+      top: 4px;
+      z-index: 2;
+    }
+  }
+
+  &:disabled:checked:after {
+    border: 0;
+    cursor: default;
+    margin-left: 1px;
+    margin-top: 1px;
+  }
+}
+
+[type=radio] {
+  -webkit-appearance: none;
+  height: $space-3;
+  padding: 0;
+  position: relative;
+  width: $space-3;
+  background: none;
+  border: 0;
+
+  &:disabled:after {
+    cursor: default;
+    background: $grey-10;
+    border: 1px solid $grey-10;
+  }
+
+  &:disabled:hover:after {
+    border-color: $grey-10;
+  }
+
+  &:after {
+    border-radius: 50%;
+    color: $grey-50;
+    content: '';
+    cursor: pointer;
+    display: block;
+    height: 14px;
+    left: 3px;
+    position: absolute;
+    top: 3px;
+    width: 14px;
+    border: 1px solid $grey-15;
+  }
+
+  &:hover:after {
+    border-color: $grey-50;
+  }
+
+  &:checked:before {
+    background: $grey-50;
+    border: 0;
+    border-radius: 5px;
+    content: '';
+    cursor: pointer;
+    height: 8px;
+    left: 7px;
+    position: absolute;
+    top: 7px;
+    width: 8px;
+    z-index: 1;
   }
 }
 
@@ -56,6 +238,10 @@ label {
   display: inline-block;
   font-size: $h6;
   line-height: 1;
+}
+
+.disabled label {
+  cursor: default;
 }
 
 fieldset {
@@ -94,185 +280,6 @@ fieldset {
   label {
 
   }
-}
-
-[type=text],
-[type=datetime],
-[type=datetime-local],
-[type=email],
-[type=month],
-[type=number],
-[type=password],
-[type=search],
-[type=tel],
-[type=time],
-[type=url],
-[type=week],
-.date-field input {
-  -webkit-appearance: none;
-  border-radius: 3px;
-  box-sizing: border-box;
-  color: $grey-75;
-  padding: $space-1;
-  vertical-align: middle;
-  width: 100%;
-
-  &:focus:not([readonly]),
-  &:hover:not([readonly]) {
-    border: 1px solid $blue-25;
-  }
-}
-
-[type=number]::-webkit-inner-spin-button,
-[type=number]::-webkit-outer-spin-button {
-  opacity: 0;
-}
-
-[type=checkbox] {
-  -webkit-appearance: none;
-  background: none;
-  height: $space-3;
-  position: relative;
-  width: $space-3;
-
-  &:disabled:after {
-    cursor: default;
-  }
-
-  &[readonly]:after {
-    cursor: default;
-  }
-
-  &:after {
-    border-radius: 3px;
-    color: $grey-50;
-    content: '';
-    cursor: pointer;
-    display: block;
-    height: $space-3;
-    position: absolute;
-    width: $space-3;
-    z-index: 1;
-  }
-
-  &:checked {
-    @include icon(check);
-    &:before {
-      color: $grey-50;
-      font-size: $h6;
-      left: 3px;
-      position: absolute;
-      top: 4px;
-      z-index: 2;
-    }
-  }
-
-  &:disabled:checked:after {
-    border: 0;
-    cursor: default;
-    margin-left: 1px;
-    margin-top: 1px;
-  }
-}
-
-[type=checkbox]:disabled:after {
-  border-radius: 3px;
-  content: '';
-  cursor: default;
-}
-
-[type=radio] {
-  -webkit-appearance: none;
-  height: 16px;
-  padding: 0;
-  position: relative;
-  width: 16px;
-
-  &:disabled:after {
-    cursor: default;
-  }
-
-  &:after {
-    border-radius: 7px;
-    color: $grey-50;
-    content: '';
-    cursor: pointer;
-    display: block;
-    height: 14px;
-    position: absolute;
-    width: 14px;
-  }
-
-  &:checked:before {
-    background: $grey-50;
-    border: 0;
-    border-radius: 5px;
-    content: '';
-    cursor: pointer;
-    height: 8px;
-    left: 4px;
-    position: absolute;
-    top: 4px;
-    width: 8px;
-    z-index: 1;
-  }
-
-}
-
-.disabled label {
-  cursor: default;
-}
-
-// fields on white background
-.field-light {
-  background: $blue-05;
-  border: 1px solid $blue-05;
-}
-
-.field-light:disabled {
-  background: $grey-10;
-  border: 1px solid $grey-10;
-
-  &:hover {
-    border: 1px solid $grey-10;
-  }
-}
-
-.field-light[type=checkbox] {
-  background: none;
-  border: 0;
-}
-
-.field-light[type=checkbox]:after {
-  border: 1px solid $grey-15;
-
-  &:hover {
-    border: 1px solid $blue-25;
-  }
-}
-
-.field-light[type=checkbox]:disabled:after {
-  background: $grey-10;
-  border: 1px solid $grey-10;
-}
-
-.field-light[type=checkbox][readonly]:after {
-  background: none;
-  border: 0;
-}
-
-.field-light[type=radio] {
-  background: none;
-  border: 0;
-}
-
-.field-light[type=radio]:after {
-  border: 1px solid $grey-15;
-}
-
-.field-light[type=radio]:disabled:after {
-  background: $grey-10;
-  border: 1px solid $grey-10;
 }
 
 // fields on dark background (grey form)
@@ -363,7 +370,7 @@ fieldset {
   }
 
   .label-right {
-    margin-left: 10px;
+    margin-left: $space-2;
     position: relative;
   }
 
@@ -377,7 +384,7 @@ fieldset {
 }
 
 .radio-field .label-right {
-  top: -1px;
+  top: -4px;
 }
 
 .simple-select {

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -51,9 +51,9 @@ label {
 .date-field input,
 textarea {
   background: $blue-05;
-  border-width: 1px;
-  border-style: solid;
   border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
   box-sizing: border-box;
   color: $grey-75;
   vertical-align: middle;
@@ -189,16 +189,16 @@ select,
 
 [type=radio] {
   -webkit-appearance: none;
+  background: none;
+  border: 0;
   height: $space-3;
   padding: 0;
   position: relative;
   width: $space-3;
-  background: none;
-  border: 0;
 
   &:after {
-    border-radius: 50%;
     border: 1px solid $grey-15;
+    border-radius: 50%;
     color: $grey-50;
     content: '';
     cursor: pointer;
@@ -211,9 +211,9 @@ select,
   }
 
   &:disabled:after {
-    cursor: default;
     background: $grey-10;
     border-color: $grey-10;
+    cursor: default;
   }
 
   &:disabled:hover:after {
@@ -271,11 +271,13 @@ fieldset {
       background: $grey-15;
       border-color: $grey-15;
       color: $grey-50;
+    }
 
-      &:focus:not([readonly]),
-      &:hover:not([readonly]) {
-        border-color: $grey-15;
-      }
+    &:focus:not([readonly]):disabled,
+    &:hover:not([readonly]):disabled,
+    &:focus:not([readonly]).disabled,
+    &:hover:not([readonly]).disabled {
+      border-color: $grey-15;
     }
   }
 
@@ -292,11 +294,13 @@ fieldset {
       background: $grey-15;
       border-color: $grey-15;
       color: $grey-50;
+    }
 
-      &:focus,
-      &:hover {
-        border-color: $grey-15;
-      }
+    &.disabled:focus,
+    &:disabled:hover,
+    &.disabled:focus,
+    &:disabled:hover {
+      border-color: $grey-15;
     }
   }
 
@@ -311,11 +315,11 @@ fieldset {
     &:disabled:after {
       background-color: $grey-15;
       border-color: $grey-15;
+    }
 
-      &:focus:not([readonly]),
-      &:hover:not([readonly]) {
-        border-color: $grey-15;
-      }
+    &:focus:not([readonly]):disabled:after,
+    &:hover:not([readonly]):disabled:after {
+      border-color: $grey-15;
     }
   }
 
@@ -325,7 +329,6 @@ fieldset {
 }
 
 .modal,
-.popContainer,
 .tooltip {
 
   [type=text],
@@ -352,11 +355,13 @@ fieldset {
       background-color: $grey-75;
       border-color: $grey-75;
       color: $grey-50;
+    }
 
-      &:focus:not([readonly]),
-      &:hover:not([readonly]) {
-        border-color: $grey-75;
-      }
+    &:focus:not([readonly]).disabled,
+    &:hover:not([readonly]):disabled,
+    &:focus:not([readonly]).disabled,
+    &:hover:not([readonly]):disabled {
+      border-color: $grey-75;
     }
   }
 
@@ -367,11 +372,13 @@ fieldset {
       background-color: $grey-75;
       border-color: $grey-75;
       color: $grey-50;
+    }
 
-      &:focus:not([readonly]),
-      &:hover:not([readonly]) {
-        border-color: $grey-75;
-      }
+    &:focus:not([readonly]).disabled,
+    &:hover:not([readonly]):disabled,
+    &:focus:not([readonly]).disabled,
+    &:hover:not([readonly]):disabled {
+      border-color: $grey-75;
     }
 
     &:focus:not([readonly]),
@@ -392,11 +399,13 @@ fieldset {
       background: $grey-75;
       border-color: $grey-75;
       color: $grey-75;
+    }
 
-      &:focus,
-      &:hover {
-        border-color: $grey-75;
-      }
+    &:focus.disabled,
+    &:hover:disabled,
+    &:focus.disabled,
+    &:hover:disabled {
+      border-color: $grey-75;
     }
   }
 

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -122,6 +122,24 @@ select,
   background: $white;
   border: 1px solid $grey-25;
 
+  &.bc-grey-50 {
+    border-color: $grey-50;
+  }
+
+  &.bc-orange {
+    border-color: $orange;
+  }
+
+  &.disabled,
+  &:disabled {
+    background: $grey-10;
+    border-color: $grey-10;
+  }
+
+  &.disabled:hover {
+    border-color: $grey-10;
+  }
+
   &:focus,
   &:hover {
     border-color: $grey-50;
@@ -374,10 +392,10 @@ fieldset {
       color: $grey-50;
     }
 
-    &:focus:not([readonly]).disabled,
-    &:hover:not([readonly]):disabled,
-    &:focus:not([readonly]).disabled,
-    &:hover:not([readonly]):disabled {
+    &.disabled:focus:not([readonly]),
+    &:disabled:hover:not([readonly]),
+    &:disabled:focus:not([readonly]),
+    &.disabled:hover:not([readonly]) {
       border-color: $grey-75;
     }
 
@@ -586,25 +604,6 @@ textarea {
 
   &.inactive input {
     background: none;
-  }
-}
-
-.simple-select {
-
-  &:hover {
-    border-color: $grey-50;
-  }
-
-  &.disabled:hover {
-    border-color: $grey-10;
-  }
-
-  &.bc-orange-hover:hover {
-    border-color: $orange;
-  }
-
-  .option:hover {
-    background-color: $grey-5;
   }
 }
 

--- a/src/scss/elements/_forms.scss
+++ b/src/scss/elements/_forms.scss
@@ -20,7 +20,9 @@ textarea {
   }
 
   &.bc-orange {
+    // scss-lint:disable ImportantRule
     border-color: $orange !important;
+    // scss-lint:disable ImportantRule
   }
 }
 
@@ -98,22 +100,37 @@ textarea {
 }
 
 // Date field inputs are always read-only
-.date-field input {
-  border-color: $blue-05;
+.date-field {
 
-  &:focus,
-  &:hover {
+  .icon-calendar {
+    color: $blue-50;
+  }
+
+  input {
+    border-color: $blue-05;
+
+    &:disabled {
+      border-color: $grey-10;
+    }
+  }
+
+  &:focus input,
+  &:hover input {
     border-color: $blue-25;
   }
 
-  &.disabled,
-  &:disabled {
-    border-color: $grey-10;
+  &:focus .icon-calendar,
+  &:hover .icon-calendar {
+    color: $blue-70;
+  }
 
-    &:focus,
-    &:hover {
-      border-color: $grey-10;
-    }
+  &:focus input:disabled,
+  &:hover input:disabled {
+    border-color: $grey-10;
+  }
+
+  &.disabled .icon-calendar {
+    color: $grey-50;
   }
 }
 
@@ -278,6 +295,7 @@ fieldset {
   .simple-select,
   textarea {
     background-color: $white;
+    border-color: $white;
 
     &:focus:not([readonly]),
     &:hover:not([readonly]) {
@@ -299,26 +317,30 @@ fieldset {
     }
   }
 
-  .date-field input {
-    background-color: $white;
+  .date-field {
 
-    &:focus,
-    &:hover {
-      border-color: $grey-50;
+    input {
+      background-color: $white;
     }
 
-    &.disabled,
-    &:disabled {
+    input:disabled {
       background: $grey-15;
       border-color: $grey-15;
       color: $grey-50;
     }
 
-    &.disabled:focus,
-    &:disabled:hover,
-    &.disabled:focus,
-    &:disabled:hover {
+    &:focus input,
+    &:hover input {
+      border-color: $grey-50;
+    }
+
+    &:focus input:disabled,
+    &:hover input:disabled {
       border-color: $grey-15;
+    }
+
+    &.disabled .icon-calendar {
+      color: $grey-50;
     }
   }
 
@@ -504,17 +526,6 @@ textarea {
     .icon-arrow-up {
       color: $blue-70;
     }
-
-    &.disabled,
-    &.disabled:focus,
-    &.disabled:hover {
-
-      .icon-arrow-double,
-      .icon-arrow-down,
-      .icon-arrow-up {
-        color: $grey-50;
-      }
-    }
   }
 
   &.disabled,
@@ -524,39 +535,6 @@ textarea {
     .icon-arrow-double,
     .icon-arrow-down,
     .icon-arrow-up {
-      color: $grey-50;
-    }
-  }
-}
-
-.date-field {
-
-  .icon-calendar {
-    color: $blue-50;
-  }
-
-  &:focus,
-  &:hover {
-
-    .icon-calendar {
-      color: $blue-70;
-    }
-
-    &.disabled,
-    &.disabled:focus,
-    &.disabled:hover {
-
-      .icon-calendar {
-        color: $grey-50;
-      }
-    }
-  }
-
-  &.disabled,
-  &.disabled:focus,
-  &.disabled:hover {
-
-    .icon-calendar {
       color: $grey-50;
     }
   }

--- a/test/forms/fields/select/simple-select.spec.js
+++ b/test/forms/fields/select/simple-select.spec.js
@@ -42,26 +42,13 @@ describe('SimpleSelect', () => {
     })
   });
 
-  describe('#arrowClasses()', () => {
-     it('returns grey arrow if disabled', () => {
-       let simple_select = TestUtils.renderIntoDocument(<SimpleSelect disabled={true}/>)
-       let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'grey-50');
-       expect(elem.length).to.equal(1)
-     })
-     it('returns blue arrow by default', () => {
-       let simple_select = TestUtils.renderIntoDocument(<SimpleSelect disabled={false}/>)
-       let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'blue-70');
-       expect(elem.length).to.equal(1)
-     })
-   });
-
-   describe('#valueBorderClass()', () => {
-      it('returns bc-orange border color if there is an error', () => {
-        let simple_select = TestUtils.renderIntoDocument(<SimpleSelect hasError={true}/>)
-        let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'bc-orange bc-orange-hover');
-        expect(elem).to.exist
-      })
-    });
+  describe('#valueBorderClass()', () => {
+    it('returns bc-orange border color if there is an error', () => {
+      let simple_select = TestUtils.renderIntoDocument(<SimpleSelect hasError={true}/>)
+      let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'bc-orange bc-orange-hover');
+      expect(elem).to.exist
+    })
+  });
 
   describe('#optionsObject()', () => {
     it('returns this.props.options when an object if passed to options prop', () => {

--- a/test/forms/fields/select/simple-select.spec.js
+++ b/test/forms/fields/select/simple-select.spec.js
@@ -39,7 +39,6 @@ describe('SimpleSelect', () => {
       simple_select.setState({show_options: true})
       TestUtils.Simulate.click(simple_select.refs.simpleSelectValue)
       expect(simple_select.state.show_options).to.be.false
-
     })
   });
 
@@ -60,21 +59,6 @@ describe('SimpleSelect', () => {
       it('returns bc-orange border color if there is an error', () => {
         let simple_select = TestUtils.renderIntoDocument(<SimpleSelect hasError={true}/>)
         let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'bc-orange bc-orange-hover');
-        expect(elem).to.exist
-      })
-      it('returns grey-25 border color if fieldColor is light', () => {
-        let simple_select = TestUtils.renderIntoDocument(<SimpleSelect fieldColor={('light')}/>)
-        let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'bc-grey-25');
-        expect(elem).to.exist
-      })
-      it('returns bc-white border color if the fieldColor is dark', () => {
-        let simple_select = TestUtils.renderIntoDocument(<SimpleSelect fieldColor={('dark')}/>)
-        let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'bc-white');
-        expect(elem).to.exist
-      })
-      it('returns grey-10 border color if the field is disabled', () => {
-        let simple_select = TestUtils.renderIntoDocument(<SimpleSelect fieldColor={('dark')} disabled={true}/>)
-        let elem = TestUtils.scryRenderedDOMComponentsWithClass(simple_select, 'bc-grey-10');
         expect(elem).to.exist
       })
     });


### PR DESCRIPTION
I don't think we need to pass props for 'field-light', et al. to all of our field components. This can be accomplished by styling children of the native `fieldset` node and the `.tooltip` class.

I'd started working on a FieldSet component and it was completely dumb, no props or any logic, just a wrapper adding functional classes.

There are a few things like PTO plan settings that use a well-style appearance, but these can be styled using functional classes. Default styles should cover all other cases.

<img width="438" alt="screen shot 2015-12-21 at 5 32 35 pm" src="https://cloud.githubusercontent.com/assets/1119770/11943053/e8e8b0a4-a808-11e5-858d-f1630dbab040.png">
<img width="437" alt="screen shot 2015-12-21 at 5 32 41 pm" src="https://cloud.githubusercontent.com/assets/1119770/11943056/eaf3674a-a808-11e5-966a-b9d2b507b9d8.png">

This PR covers the following tasks:
- [x] Update forms.js to use native `fieldset`
- [x] Add default style for `fieldset` element
- [x] Update `forms.scss` to style children of `fieldset`
- [x] Create styles in `forms.scss` for forms inside popups
- [x] Fix missing / incorrect hover styles for `inputs` in all three parents 
- [x] Remove `fieldColor` props from all fields