### PR TITLE
get value from simpleSelect

### DIFF
--- a/src/js/components/forms/fields/select/select.es6
+++ b/src/js/components/forms/fields/select/select.es6
@@ -68,7 +68,8 @@ export default React.createClass({
     return (
       <div>
         {this.label()}
-        <SimpleSelect disabled={this.props.disabled}
+        <SimpleSelect ref='simpleSelect'
+                      disabled={this.props.disabled}
                       fieldColor={this.props.fieldColor}
                       hasError={this.state.errors.length > 0}
                       includeBlank={this.props.includeBlank}

--- a/src/js/pages/forms.js
+++ b/src/js/pages/forms.js
@@ -56,24 +56,23 @@ export default React.createClass({
   },
 
   onSimpleSelect1Change() {
-    console.log(this.refs);
-    this.setState({simpleSelect1Value: this.refs.simpleSelect1.state.value})
+    this.setState({simpleSelect1Value: this.refs.simpleSelect1.refs.simpleSelect.state.value})
   },
 
   onSimpleSelect2Change() {
-    this.setState({simpleSelect2Value: this.refs.simpleSelect2.state.value})
+    this.setState({simpleSelect2Value: this.refs.simpleSelect2.refs.simpleSelect.state.value})
   },
 
   onSimpleSelect3Change() {
-    this.setState({simpleSelect3Value: this.refs.simpleSelect3.state.value})
+    this.setState({simpleSelect3Value: this.refs.simpleSelect3.refs.simpleSelect.state.value})
   },
 
   onSimpleSelect4Change() {
-    this.setState({simpleSelect4Value: this.refs.simpleSelect4.state.value})
+    this.setState({simpleSelect4Value: this.refs.simpleSelect4.refs.simpleSelect.state.value})
   },
 
   onSimpleSelect5Change() {
-    this.setState({simpleSelect5Value: this.refs.simpleSelect5.state.value})
+    this.setState({simpleSelect5Value: this.refs.simpleSelect5.refs.simpleSelect.state.value})
   },
 
   _onSave(value) {


### PR DESCRIPTION
adding `ref=simpleSelect` allows us to get the value from the select field's parent component

Not sure if I like this, but and wondering what other people think.  Accessing the value from the event wasn't really working, since we're not using an actual html select here.  