### PR TITLE
feat(lists/sortable-table): adds working sortable table w/ example

### DIFF
--- a/src/js/components/lists/index.js
+++ b/src/js/components/lists/index.js
@@ -1,1 +1,1 @@
-export { default as SortableTable } from './sortable-table';
+export { default as Sortable } from './sortable';

--- a/src/js/components/lists/sortable-table-header-cell.es6
+++ b/src/js/components/lists/sortable-table-header-cell.es6
@@ -21,13 +21,13 @@ class SortableTableHeaderCell extends React.Component {
       sortKey
     } = this.props;
 
-    if (!sort.key && active && sortKey) {
-      sort.key = sortKey;
-      actions.sort(sort);
-    }
+    if (active) {
+      // assigns values to "sort" if they don't exist yet
+      Object.assign(sort, {
+        key: sort.key || sortKey,
+        order: sort.order || order
+      });
 
-    if (!sort.order && active) {
-      sort.order = order;
       actions.sort(sort);
     }
   }

--- a/src/js/components/lists/sortable-table-header-cell.es6
+++ b/src/js/components/lists/sortable-table-header-cell.es6
@@ -1,0 +1,135 @@
+import React from 'react';
+
+const {
+  createClass,
+  Children,
+  PropTypes,
+} = React;
+
+export default createClass({
+
+  displayName: "SortableTableHeaderCell",
+
+  propTypes: {
+    order: PropTypes.string,
+    sortKey: PropTypes.string,
+    active: PropTypes.bool,
+  },
+
+  getDefaultProps() {
+    return {
+      active: false,
+      order: "asc",
+    }
+  },
+
+  componentWillMount() {
+    const {
+      actions,
+      active,
+      order,
+      sort,
+      sortKey
+    } = this.props;
+
+    if (!sort.key && active && sortKey) {
+      sort.key = sortKey;
+      actions.sort(sort);
+    }
+
+    if (!sort.order && active) {
+      sort.order = order;
+      actions.sort(sort);
+    }
+  },
+
+  // sets classes for arrows, utility classes, etc
+  setClassName() {
+    const classes = [],
+      {
+        sort,
+        sortKey,
+      } = this.props;
+
+    // some header cells might not be sortable, so check for the sortKey prop
+    if (sortKey) {
+      classes.push('pointer');
+    }
+
+    classes.push(this.props.className);
+
+    return classes.join(' ')
+  },
+
+  handleClick() {
+    const {
+      actions,
+      sortKey
+    } = this.props;
+
+    if (sortKey) {
+      var sort = {
+        key: sortKey,
+        order: this.handleOrder()
+      }
+
+      actions.sort(sort);
+    }
+  },
+
+  handleOrder() {
+    const {
+      order,
+      sort,
+      sortKey
+    } = this.props;
+
+    if (sort.key === sortKey) {
+      return sort.order === "asc" ? "desc" : "asc";
+    } else {
+      return order
+    }
+  },
+
+  renderArrow(){
+    let icon = "arrow-double";
+    const {
+      sort,
+      sortKey,
+    } = this.props;
+
+    // check if this is a sortable column
+    if (sortKey) {
+      // check if this is the currently sorted column
+      if (sort.key === sortKey) {
+        // check the direction
+        icon = (sort.order === 'desc') ? 'arrow-down' : 'arrow-up';
+      }
+      return <span className={`ml1 blue-50 small pointer icon-${icon}`} ></span>;
+    }
+  },
+
+  renderCellContent() {
+    const children = [];
+
+    Children.forEach(this.props.children, function(child) {
+      children.push(child);
+    });
+
+    return (
+      <span className="flex flex-center">
+        {children[0]}
+        {this.renderArrow()}
+        {children.slice(1)}
+      </span>
+    );
+  },
+
+  render() {
+    return (
+      <th className={this.setClassName()} style={this.props.style} onClick={this.handleClick}>
+        {this.renderCellContent()}
+      </th>
+    );
+  }
+});

--- a/src/js/components/lists/sortable-table-header-cell.es6
+++ b/src/js/components/lists/sortable-table-header-cell.es6
@@ -1,27 +1,16 @@
 import React from 'react';
 
 const {
-  createClass,
   Children,
-  PropTypes,
+  PropTypes
 } = React;
 
-export default createClass({
+class SortableTableHeaderCell extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.handleClick = this.handleClick.bind(this);
+  }
 
-  displayName: "SortableTableHeaderCell",
-
-  propTypes: {
-    order: PropTypes.string,
-    sortKey: PropTypes.string,
-    active: PropTypes.bool,
-  },
-
-  getDefaultProps() {
-    return {
-      active: false,
-      order: "asc",
-    }
-  },
 
   componentWillMount() {
     const {
@@ -41,7 +30,7 @@ export default createClass({
       sort.order = order;
       actions.sort(sort);
     }
-  },
+  }
 
   // sets classes for arrows, utility classes, etc
   setClassName() {
@@ -59,7 +48,7 @@ export default createClass({
     classes.push(this.props.className);
 
     return classes.join(' ')
-  },
+  }
 
   handleClick() {
     const {
@@ -75,7 +64,7 @@ export default createClass({
 
       actions.sort(sort);
     }
-  },
+  }
 
   handleOrder() {
     const {
@@ -89,9 +78,9 @@ export default createClass({
     } else {
       return order
     }
-  },
+  }
 
-  renderArrow(){
+  renderArrow() {
     let icon = "arrow-double";
     const {
       sort,
@@ -107,7 +96,7 @@ export default createClass({
       }
       return <span className={`ml1 blue-50 small pointer icon-${icon}`} ></span>;
     }
-  },
+  }
 
   renderCellContent() {
     const children = [];
@@ -123,7 +112,7 @@ export default createClass({
         {children.slice(1)}
       </span>
     );
-  },
+  }
 
   render() {
     return (
@@ -132,4 +121,20 @@ export default createClass({
       </th>
     );
   }
-});
+};
+
+SortableTableHeaderCell.displayName = "SortableTableHeaderCell";
+
+SortableTableHeaderCell.propTypes = {
+  order: PropTypes.string,
+  sortKey: PropTypes.string,
+  active: PropTypes.bool
+};
+
+
+SortableTableHeaderCell.defaultProps = {
+  active: false,
+  order: "asc"
+};
+
+export default SortableTableHeaderCell;

--- a/src/js/components/lists/sortable.es6
+++ b/src/js/components/lists/sortable.es6
@@ -75,11 +75,14 @@ class Sortable extends React.Component {
   _getValue(children, key) {
     let value = null;
 
-    Children.forEach(children, (child) => {
+    for (let i = 0, len = Children.count(children); i < len; i++) {
+      let child = children[i];
+
       if (child.props[key]) {
         value = child.props[key];
+        break;
       }
-    });
+    }
 
     return value;
   }

--- a/src/js/components/lists/sortable.es6
+++ b/src/js/components/lists/sortable.es6
@@ -1,0 +1,151 @@
+// react
+import React from 'react';
+
+const {
+  createClass,
+  Children
+} = React;
+
+// sub components
+import HeaderCell from './sortable-table-header-cell';
+
+// component
+const Sortable = createClass({
+
+  displayName: "Sortable",
+
+  getInitialState() {
+    return {
+      loading: true,
+      sort: {
+        key: null,
+        order: null
+      }
+    };
+  },
+
+  handleSort(sort) {
+    this.setState({
+      loading: true,
+      sort: sort
+    });
+  },
+
+  _getHeaderCells(children) {
+    return Children.map(children, (child) => {
+      if (child.type === 'th') {
+        return (
+          <HeaderCell 
+            {...child.props} 
+            {...this.state}
+            actions={{
+              sort: this.handleSort
+            }}
+          >
+            {child.props.children}
+          </HeaderCell>
+        );
+      }
+    });
+  },
+
+  _getHeaderRow(children) {
+    return Children.map(children, (child) => {
+      if (child.type === 'tr') {
+        return (
+          <tr {...child.props}>
+            {this._getHeaderCells(child.props.children)}
+          </tr>
+        );
+      }
+    });
+  },
+
+  _getHeader(children) {
+    return Children.map(children, (child) => {
+      if (child.type === 'thead') {
+        return (
+          <thead {...child.props}>
+            {this._getHeaderRow(child.props.children)}
+          </thead>
+        );
+      }
+    });
+  },
+
+  _getValue(children, key) {
+    let value = null;
+
+    Children.forEach(children, (child) => {
+      if (child.props[key]) {
+        value = child.props[key];
+      }
+    });
+
+    return value;
+  },
+
+  _getBodyRows(children) {
+    const {
+      sort
+    } = this.state;
+
+    if (sort.key) {
+      let sortedChildren = children.sort((child, nextChild) => {
+        let val = this._getValue(child.props.children, sort.key);
+        let nextVal = this._getValue(nextChild.props.children, sort.key);
+
+        if (typeof val === 'string') {
+          return val.localeCompare(nextVal);
+        } else if (typeof val === 'number') {
+          return val - nextVal;
+        } else {
+          return val;
+        }
+      });
+
+      if (sort.order === 'desc') {
+        sortedChildren = sortedChildren.reverse();
+      }
+
+      return sortedChildren;
+    } else {
+      return children;
+    }
+  },
+
+  _getBody(children) {
+    return Children.map(children, (child) => {
+      if (child.type === 'tbody') {
+        return (
+          <tbody {...child.props}>
+            {this._getBodyRows(child.props.children)}
+          </tbody>
+        );
+      }
+    });
+  },
+
+  children() {
+    let parsedTable;
+
+    Children.forEach(this.props.children, (child) => {
+      if (child.type === 'table') {
+        parsedTable = (
+          <table {...child.props}>
+            {this._getHeader(child.props.children)}
+            {this._getBody(child.props.children)}
+          </table>
+        );
+      }
+    });
+
+    return parsedTable;
+  },
+
+  render() {
+    return this.children();
+  }
+});
+
+export default Sortable;

--- a/src/js/components/lists/sortable.es6
+++ b/src/js/components/lists/sortable.es6
@@ -2,7 +2,6 @@
 import React from 'react';
 
 const {
-  createClass,
   Children
 } = React;
 
@@ -10,26 +9,26 @@ const {
 import HeaderCell from './sortable-table-header-cell';
 
 // component
-const Sortable = createClass({
+class Sortable extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.handleSort = this.handleSort.bind(this);
 
-  displayName: "Sortable",
-
-  getInitialState() {
-    return {
+    this.state = {
       loading: true,
       sort: {
         key: null,
         order: null
       }
     };
-  },
+  }
 
   handleSort(sort) {
     this.setState({
       loading: true,
       sort: sort
     });
-  },
+  }
 
   _getHeaderCells(children) {
     return Children.map(children, (child) => {
@@ -47,7 +46,7 @@ const Sortable = createClass({
         );
       }
     });
-  },
+  }
 
   _getHeaderRow(children) {
     return Children.map(children, (child) => {
@@ -59,7 +58,7 @@ const Sortable = createClass({
         );
       }
     });
-  },
+  }
 
   _getHeader(children) {
     return Children.map(children, (child) => {
@@ -71,7 +70,7 @@ const Sortable = createClass({
         );
       }
     });
-  },
+  }
 
   _getValue(children, key) {
     let value = null;
@@ -83,7 +82,7 @@ const Sortable = createClass({
     });
 
     return value;
-  },
+  }
 
   _getBodyRows(children) {
     const {
@@ -112,7 +111,7 @@ const Sortable = createClass({
     } else {
       return children;
     }
-  },
+  }
 
   _getBody(children) {
     return Children.map(children, (child) => {
@@ -124,7 +123,7 @@ const Sortable = createClass({
         );
       }
     });
-  },
+  }
 
   children() {
     let parsedTable;
@@ -141,11 +140,13 @@ const Sortable = createClass({
     });
 
     return parsedTable;
-  },
+  }
 
   render() {
     return this.children();
   }
-});
+}
+
+Sortable.displayName = "Sortable";
 
 export default Sortable;

--- a/src/js/pages/tables.js
+++ b/src/js/pages/tables.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Styleguide from '../styleguide';
+import Sortable from '../components/lists/sortable';
 
 export default React.createClass({
   displayName: "TablesPage",
@@ -48,35 +49,34 @@ export default React.createClass({
         </table>
 
         <h3 className="mb0">Sortable Tables</h3>
-        <table>
-          <thead>
-            <tr>
-              <th><a href="#" className="block">First</a></th>
-              <th><a href="#" className="block">Last</a></th>
-              <th><a href="#" className="block">Start Date</a></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>John</td>
-              <td>Smith</td>
-              <td>2014-01-01</td>
-            </tr>
-            <tr>
-              <td>Chuck</td>
-              <td>D</td>
-              <td>2013-03-15</td>
-            </tr>
-            <tr>
-              <td>Flava</td>
-              <td>Flav</td>
-              <td>2012-06-28</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <p className="orange">Need to add in some arrows.</p>
-
+        <Sortable>
+          <table>
+            <thead>
+              <tr>
+                <th sortKey="name"><a href="#" className="block">First</a></th>
+                <th><a href="#" className="block">Last</a></th>
+                <th sortKey="date" active={true} order="desc"><a href="#" className="block">Start Date</a></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td name="john">John</td>
+                <td>Smith</td>
+                <td date={2014}>2014-01-01</td>
+              </tr>
+              <tr>
+                <td name="chuck">Chuck</td>
+                <td>D</td>
+                <td date={2013}>2013-03-15</td>
+              </tr>
+              <tr>
+                <td name="flava">Flava</td>
+                <td>Flav</td>
+                <td date={2012}>2012-06-28</td>
+              </tr>
+            </tbody>
+          </table>
+        </Sortable>
       </div>
 
     </Styleguide>

--- a/src/js/pages/tables.js
+++ b/src/js/pages/tables.js
@@ -53,9 +53,9 @@ export default React.createClass({
           <table>
             <thead>
               <tr>
-                <th sortKey="name"><a href="#" className="block">First</a></th>
-                <th><a href="#" className="block">Last</a></th>
-                <th sortKey="date" active={true} order="desc"><a href="#" className="block">Start Date</a></th>
+                <th sortKey="name">First</th>
+                <th>Last</th>
+                <th sortKey="date" active={true}>Start Date</th>
               </tr>
             </thead>
             <tbody>

--- a/test/lists/sortable.spec.js
+++ b/test/lists/sortable.spec.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import TestUtils from 'react/lib/ReactTestUtils';
+import React from 'react';
+import Sortable from 'lists/sortable';
+import Sinon from 'sinon';
+
+describe('Sortable', () => {
+  it('renders', () => {
+    let sortable = TestUtils.renderIntoDocument(
+      <Sortable>
+        <table>
+          <thead>
+            <tr>
+              <th sortKey="name"><a href="#" className="block">First</a></th>
+              <th><a href="#" className="block">Last</a></th>
+              <th sortKey="date" active={true} order="desc"><a href="#" className="block">Start Date</a></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td name="john">John</td>
+              <td>Smith</td>
+              <td date={2014}>2014-01-01</td>
+            </tr>
+            <tr>
+              <td name="chuck">Chuck</td>
+              <td>D</td>
+              <td date={2013}>2013-03-15</td>
+            </tr>
+            <tr>
+              <td name="flava">Flava</td>
+              <td>Flav</td>
+              <td date={2012}>2012-06-28</td>
+            </tr>
+          </tbody>
+        </table>
+      </Sortable>
+    );
+  });
+});

--- a/test/lists/sortable.spec.js
+++ b/test/lists/sortable.spec.js
@@ -1,19 +1,20 @@
 import { expect } from 'chai';
-import TestUtils from 'react/lib/ReactTestUtils';
-import React from 'react';
-import Sortable from 'lists/sortable';
 import Sinon from 'sinon';
+import React from 'react';
+import TestUtils from 'react/lib/ReactTestUtils';
+import Sortable from 'lists/sortable';
 
 describe('Sortable', () => {
-  it('renders', () => {
-    let sortable = TestUtils.renderIntoDocument(
+  let sortable;
+  beforeEach(() => {
+    sortable = TestUtils.renderIntoDocument(
       <Sortable>
         <table>
           <thead>
             <tr>
               <th sortKey="name"><a href="#" className="block">First</a></th>
               <th><a href="#" className="block">Last</a></th>
-              <th sortKey="date" active={true} order="desc"><a href="#" className="block">Start Date</a></th>
+              <th sortKey="date" active={true}><a href="#" className="block">Start Date</a></th>
             </tr>
           </thead>
           <tbody>
@@ -36,5 +37,47 @@ describe('Sortable', () => {
         </table>
       </Sortable>
     );
+  });
+
+  it('renders', () => {
+    let headers = TestUtils.scryRenderedDOMComponentsWithTag(sortable, 'th');
+    let rows = TestUtils.scryRenderedDOMComponentsWithTag(sortable, 'tr');
+
+    expect(headers.length).to.eql(3);
+    expect(rows.length).to.eql(4);
+    
+    expect(rows[1].props.children.length).to.eql(3);
+  });
+
+  it('sorts', () => {
+    let bodyCells = TestUtils.scryRenderedDOMComponentsWithTag(sortable, 'td');
+    let headers = React.findDOMNode(sortable).querySelectorAll('th');
+
+    // the first cell should be Flava because the row is initially ordered by date in ascending order
+    expect(
+      React.findDOMNode(bodyCells[0]).textContent
+    ).to.eql('Flava');
+
+    // the date column header should have an up-arrow while the inactive name column should have double-arrow
+    expect(
+      headers[2].querySelectorAll('.icon-arrow-up').length
+    ).to.eql(1);
+    expect(
+      headers[0].querySelectorAll('.icon-arrow-double').length
+    ).to.eql(1);
+
+    TestUtils.Simulate.click(headers.item(0));
+
+    // the first cell should be Chuck because the First column header was clicked
+    expect(
+      React.findDOMNode(bodyCells[0]).textContent
+    ).to.eql('Chuck');
+
+    expect(
+      headers[0].querySelectorAll('.icon-arrow-up').length
+    ).to.eql(1);
+    expect(
+      headers[2].querySelectorAll('.icon-arrow-double').length
+    ).to.eql(1);
   });
 });


### PR DESCRIPTION
Keeps the same setup style as `Sortable` in HCM, using only other component and no `underscore` dependency. 

Video Preview: http://quick.as/zngCXXjQ

Needs: 

- [x] tests