### PR TITLE
fix(fields): adds 'name' props to TextField & TextAreaField

### DIFF
--- a/src/js/components/forms/fields/text.es6
+++ b/src/js/components/forms/fields/text.es6
@@ -10,6 +10,7 @@ export default React.createClass({
     disabled: Type.bool,
     extraClasses: Type.arrayOf(Type.string),
     label: Type.string,
+    name: Type.string,
     placeholder: Type.string
   },
 
@@ -23,7 +24,7 @@ export default React.createClass({
 
   label() {
     if(this.props.label) {
-      return <label htmlFor={this.props.id} className="px2 mb1">{this.props.label}</label>;
+      return <label htmlFor={this.props.name} className="px2 mb1">{this.props.label}</label>;
     }
   },
 
@@ -41,6 +42,8 @@ export default React.createClass({
         {this.label()}
         <input disabled={this.props.disabled}
                type="text"
+               name={this.props.name}
+               id={this.props.name}
                placeholder={this.props.placeholder}
                readOnly={this.props.inactive || this.props.readOnly} />
       </div>

--- a/src/js/components/forms/fields/textarea.es6
+++ b/src/js/components/forms/fields/textarea.es6
@@ -10,6 +10,7 @@ export default React.createClass({
     disabled: Type.bool,
     extraClasses: Type.arrayOf(Type.string),
     label: Type.string,
+    name: Type.string,
     placeholder: Type.string,
     readOnly: Type.bool,
     expandable: Type.bool
@@ -24,7 +25,7 @@ export default React.createClass({
 
   label() {
     if(this.props.label) {
-      return <label htmlFor={this.props.id} className="px2 mb1">{this.props.label}</label>;
+      return <label htmlFor={this.props.name} className="px2 mb1">{this.props.label}</label>;
     }
   },
 
@@ -52,6 +53,8 @@ export default React.createClass({
         <textarea disabled={this.props.disabled}
                   readOnly={this.props.readOnly}
                   placeholder={this.props.placeholder}
+                  name={this.props.name}
+                  id={this.props.name}
                   onChange={this.props.expandable ? this.expand : null} />
       </div>
   }

--- a/src/js/pages/forms.js
+++ b/src/js/pages/forms.js
@@ -95,7 +95,7 @@ export default React.createClass({
           <form className="clearfix">
             <hr />
             <p>Default fields</p>
-            <TextField label="Text" placeholder="Placeholder" extraClasses={['py2']} />
+            <TextField label="Text" name="firstTextField" placeholder="Placeholder" extraClasses={['py2']} />
             <NumberField label="Number" extraClasses={['py2']} units="Units"  />
             <DateField
               dateFormat='MMM D, YYYY'
@@ -113,7 +113,7 @@ export default React.createClass({
               </select>
             </div>
             <SelectField label="React Select" options={simpleSelectOptions1} promptText="- Select -" extraClasses={['py2']}/>
-            <TextAreaField label="Textarea" extraClasses={['py2']} />
+            <TextAreaField label="Textarea" extraClasses={['py2']} name="firstTextArea" />
             <TextAreaField label="Textarea Expandable" expandable={true} extraClasses={['py2']} />
             <CheckboxField label="Checkbox" extraClasses={['py2']}/>
             <CheckboxField label="Checked read-only" readOnly={true} checked={true} extraClasses={['py2']}/>


### PR DESCRIPTION
This is a hotfix (patch) for the current salary build. No breaking changes. 

I'm working on another branch to refactor the existing fields to use the upcoming `FieldBase` but this is needed before that is ready.