### PR TITLE
Use lodash.assign instead of Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "alt": "^0.17.1",
     "core-js": "^0.9.6",
     "lodash": "^4.0.1",
+    "lodash.assign": "^3.2.0",
     "moment": "2.10.3",
     "react": "0.13.3",
     "react-select": "^0.4.9"

--- a/src/js/components/forms/fields/checkbox.es6
+++ b/src/js/components/forms/fields/checkbox.es6
@@ -1,3 +1,4 @@
+import assign from 'lodash.assign';
 import React from 'react';
 import { fieldProps, FieldBase} from './base.es6';
 import omit from '../../utils/omit';
@@ -94,11 +95,11 @@ class CheckboxField extends FieldBase {
 
 CheckboxField.displayName = 'CheckboxField';
 
-CheckboxField.propTypes = Object.assign({
+CheckboxField.propTypes = assign({
   options: Type.oneOfType([Type.object, Type.array]).isRequired,
 }, fieldProps);
 
-CheckboxField.defaultProps = Object.assign({
+CheckboxField.defaultProps = assign({
   defaultValue: []
 }, FieldBase.defaultProps);
 

--- a/src/js/components/forms/fields/date/date.es6
+++ b/src/js/components/forms/fields/date/date.es6
@@ -1,3 +1,4 @@
+import assign from 'lodash.assign';
 import React from 'react';
 import DatePicker from './date-picker';
 import { fieldProps, FieldBase } from '../base.es6';
@@ -153,7 +154,7 @@ class DateField extends FieldBase {
 
 DateField.displayName = "DateField";
 
-DateField.propTypes = Object.assign({
+DateField.propTypes = assign({
   dateFormat: Type.oneOf(validDateFormats).isRequired,
   includeMaxMinBounds: Type.bool,
   maxDate: Type.oneOfType([Type.object, Type.string, Type.number]),

--- a/src/js/components/forms/fields/file.es6
+++ b/src/js/components/forms/fields/file.es6
@@ -1,3 +1,4 @@
+import assign from 'lodash.assign';
 import React from 'react/addons';
 import { fieldProps, FieldBase} from './base.es6';
 import omit from '../../utils/omit';
@@ -77,13 +78,13 @@ class FileField extends FieldBase {
 
 FileField.displayName = "FileField";
 
-FileField.propTypes = Object.assign({
+FileField.propTypes = assign({
   buttonClasses: Type.array,
   buttonText: Type.string,
   icon: Type.string
 }, fieldProps);
 
-FileField.defaultProps = Object.assign({
+FileField.defaultProps = assign({
   buttonClasses: ["button-secondary", "white", "rounded-2", "p1", "pointer"],
   buttonText: "Upload File"
 }, FieldBase.defaultProps);

--- a/src/js/components/forms/fields/number.es6
+++ b/src/js/components/forms/fields/number.es6
@@ -1,3 +1,4 @@
+import assign from 'lodash.assign';
 import React from 'react';
 import { fieldProps, FieldBase} from './base.es6';
 import omit from '../../utils/omit';
@@ -56,7 +57,7 @@ class NumberField extends FieldBase {
 
 NumberField.displayName = "NumberField";
 
-NumberField.propTypes = Object.assign({
+NumberField.propTypes = assign({
   units: Type.string
 }, fieldProps);
 

--- a/src/js/components/forms/fields/radio.es6
+++ b/src/js/components/forms/fields/radio.es6
@@ -1,3 +1,4 @@
+import assign from 'lodash.assign';
 import React from 'react';
 import { fieldProps, FieldBase} from './base.es6';
 import omit from '../../utils/omit';
@@ -74,7 +75,7 @@ class RadioField extends FieldBase {
 
 RadioField.displayName = 'RadioField';
 
-RadioField.propTypes = Object.assign({
+RadioField.propTypes = assign({
   options: Type.oneOfType([Type.object, Type.array]).isRequired,
 }, fieldProps);
 

--- a/src/js/components/forms/fields/select/select.es6
+++ b/src/js/components/forms/fields/select/select.es6
@@ -1,3 +1,4 @@
+import assign from 'lodash.assign';
 import React from 'react';
 import SimpleSelect from './simple-select';
 import { fieldProps, FieldBase} from '../base.es6';
@@ -31,7 +32,7 @@ class SelectField extends FieldBase {
 
 SelectField.displayName = "SelectField";
 
-SelectField.propTypes = Object.assign({
+SelectField.propTypes = assign({
   includeBlank: Type.oneOfType([Type.bool, Type.string]),
   options: Type.oneOfType([Type.object, Type.array]).isRequired
 }, fieldProps);

--- a/src/js/components/forms/fields/textarea.es6
+++ b/src/js/components/forms/fields/textarea.es6
@@ -1,3 +1,4 @@
+import assign from 'lodash.assign';
 import React from 'react';
 import { fieldProps, FieldBase} from './base.es6';
 import omit from '../../utils/omit';
@@ -35,11 +36,11 @@ class TextAreaField extends FieldBase {
 
 TextAreaField.displayName = "TextAreaField";
 
-TextAreaField.propTypes = Object.assign({
+TextAreaField.propTypes = assign({
   expandable: Type.bool
 }, fieldProps);
 
-TextAreaField.defaultProps = Object.assign({
+TextAreaField.defaultProps = assign({
   expandable: false
 }, FieldBase.defaultProps);
 

--- a/src/js/components/utils/omit.es6
+++ b/src/js/components/utils/omit.es6
@@ -1,6 +1,8 @@
+import assign from 'lodash.assign';
+
 export default (obj, ...props) => {
   // copy the object
-  let newObj = Object.assign({}, obj);
+  let newObj = assign({}, obj);
 
   // delete all the props in ...props from the new object
   for (let prop of props) {


### PR DESCRIPTION
Download chrome 43.0.2357.134 http://google-chrome.en.uptodown.com/mac/old

Login to namely locally, note `Object.assign is not a function` <img width="1348" alt="screen shot 2016-03-14 at 03 12 41" src="https://cloud.githubusercontent.com/assets/3466499/13734170/1e113fdc-e993-11e5-9c4e-bf5d2bfd0110.png">


I had to use a version of `lodash.assgin` that matched namely's, otherwise company goals would break <img width="1348" alt="screen shot 2016-03-14 at 03 07 33" src="https://cloud.githubusercontent.com/assets/3466499/13734161/fd918712-e992-11e5-8d44-216b9416e5f2.png">

