### PR TITLE
IE fix for CheckboxField

### DIFF
--- a/src/js/components/forms/fields/checkbox.es6
+++ b/src/js/components/forms/fields/checkbox.es6
@@ -20,9 +20,8 @@ class CheckboxField extends FieldBase {
 
   onChange() {
     const values = [];
-    const {
-      elements
-    } = React.findDOMNode(this.refs.fieldset);
+    const fieldset = React.findDOMNode(this.refs.fieldset);
+    const elements = this.getElements(fieldset);
 
     for (let i = 0, len = elements.length; i < len; i++) {
       let {
@@ -36,6 +35,17 @@ class CheckboxField extends FieldBase {
     }
 
     this.handleChange(values);
+  }
+
+  getElements(fieldset) {
+    let { elements } = fieldset;
+
+    // the elements property is unsupported in IE
+    if (elements == undefined) {
+      elements = fieldset.getElementsByTagName('input');
+    }
+
+    return elements;
   }
 
   renderOption(value, index, label) {

--- a/test/forms/fields/checkbox.spec.js
+++ b/test/forms/fields/checkbox.spec.js
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import TestUtils from 'react/lib/ReactTestUtils';
+import React from 'react';
+import CheckboxField from 'forms/fields/checkbox';
+
+describe('CheckboxField', () => {
+  describe('value()', () => {
+    it('returns empty Array by default', () => {
+      expect(
+        TestUtils.renderIntoDocument(
+          <CheckboxField
+            name="default_checkbox"
+            options={['value1', 'value2']}
+          />
+        ).value()
+      ).to.eql([]);
+    });
+
+    it('returns array with defaultValue when set', () => {
+      const component = TestUtils.renderIntoDocument(
+        <CheckboxField
+          name="default_checkbox"
+          options={['value1', 'value2']}
+          defaultValue={['value2']}
+        />
+      );
+
+      expect(
+        component.value()
+      ).to.eql(['value2']);
+      
+      expect(
+        React.findDOMNode(component).getElementsByTagName('input')[0].checked
+      ).to.be.false;
+
+      expect(
+        React.findDOMNode(component).getElementsByTagName('input')[1].checked
+      ).to.be.true;
+    });
+
+    it('returns array with defaultValue when set with object', () => {
+      const component = TestUtils.renderIntoDocument(
+        <CheckboxField
+          name="default_checkbox"
+          options={{
+            value1: 'some value',
+            value2: 'another value'
+          }}
+          defaultValue={['value2']}
+        />
+      );
+
+      expect(
+        component.value()
+      ).to.eql(['value2']);
+      
+      expect(
+        React.findDOMNode(component).getElementsByTagName('input')[0].checked
+      ).to.be.false;
+
+      expect(
+        React.findDOMNode(component).querySelectorAll('span.label-right')[0].textContent
+      ).to.eql("some value");
+
+      expect(
+        React.findDOMNode(component).getElementsByTagName('input')[1].checked
+      ).to.be.true;
+
+      expect(
+        React.findDOMNode(component).querySelectorAll('span.label-right')[1].textContent
+      ).to.eql("another value");
+    });
+  });
+
+  describe('onChange()', () => {
+    it('triggers the onChange function when changed', (done) => {
+      const component = TestUtils.renderIntoDocument(
+        <CheckboxField
+          name="default_checkbox"
+          options={['value1', 'value2']}
+          onChange={(value) => {
+            expect(value)
+            .to.eql(['value1']);
+
+            done();
+          }}
+        />
+      );
+
+      const firstCheckbox = React.findDOMNode(component).getElementsByTagName('input')[0];
+
+      firstCheckbox.checked = true;
+      TestUtils.Simulate.change(firstCheckbox);
+    });
+  });
+});


### PR DESCRIPTION
When getting `values` inside the CheckboxField, I attempt to grab the `elements` property from the `fieldset` node. Before today, I was not aware that property was unsupported in IE. To resolve that issue, I've created the `getElements` method in the component to use `elements` if it's defined, then fallback to `getElementsByTagName` when needed (IE). 

I've also added a test spec for this component. 

Fixes https://namely.atlassian.net/browse/BR-941