### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Namely Styleguide (a.k.a Namely-UI / Namely-Bootstrap)
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5b20524c922b4252ac2766ca667f46ad)](https://app.codacy.com/gh/namely/styleguide/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/5b20524c922b4252ac2766ca667f46ad)](https://app.codacy.com/gh/namely/styleguide/dashboard)
 
 This is the styleguide app to document all the components and patterns for Namely.
 


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.